### PR TITLE
Introduced ChecksumType: an enum for all supported checksum types.

### DIFF
--- a/udtc/frameworks/android.py
+++ b/udtc/frameworks/android.py
@@ -26,7 +26,8 @@ import logging
 import os
 import re
 import udtc.frameworks.baseinstaller
-from udtc.tools import create_launcher, get_application_desktop_file, get_current_arch, copy_icon, add_to_user_path
+from udtc.tools import create_launcher, get_application_desktop_file, get_current_arch, copy_icon, add_to_user_path, \
+    ChecksumType
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +37,8 @@ _supported_archs = ['i386', 'amd64']
 class AndroidCategory(udtc.frameworks.BaseCategory):
 
     def __init__(self):
-        super().__init__(name=_("Android"), description=_("Android Development Environment"),
+        super().__init__(name=_("Android"),
+                         description=_("Android Development Environment"),
                          logo_path=None,
                          packages_requirements=["openjdk-7-jdk", "libncurses5:i386", "libstdc++6:i386", "zlib1g:i386"])
 
@@ -77,8 +79,9 @@ class AndroidStudio(udtc.frameworks.baseinstaller.BaseInstaller):
         super().__init__(name="Android Studio", description="Android Studio (default)", is_category_default=True,
                          category=category, only_on_archs=_supported_archs, expect_license=True,
                          download_page="https://developer.android.com/sdk/installing/studio.html",
-                         require_md5=True,
-                         dir_to_decompress_in_tarball="android-studio", desktop_filename="android-studio.desktop")
+                         checksum_type=ChecksumType.sha1,
+                         dir_to_decompress_in_tarball="android-studio",
+                         desktop_filename="android-studio.desktop")
 
     def parse_license(self, line, license_txt, in_license):
         """Parse Android Studio download page for license"""
@@ -118,7 +121,7 @@ class EclipseAdt(udtc.frameworks.baseinstaller.BaseInstaller):
         super().__init__(name="Eclipse ADT", description="Android Developer Tools (using eclipse)",
                          category=category, only_on_archs=_supported_archs, expect_license=True,
                          download_page="https://developer.android.com/sdk/index.html",
-                         require_md5=True,
+                         checksum_type=ChecksumType.md5,
                          dir_to_decompress_in_tarball="adt-bundle-linux-*", desktop_filename="adt.desktop",
                          icon_filename="adt.png")
 

--- a/udtc/frameworks/ide.py
+++ b/udtc/frameworks/ide.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2014 Canonical
 #
 # Authors:
-#  Didier Roche
+# Didier Roche
 #  Tin Tvrtković
 #
 # This program is free software; you can redistribute it and/or modify it under
@@ -27,8 +27,9 @@ import platform
 
 from os.path import join
 import udtc.frameworks.baseinstaller
-from udtc.network.download_center import DownloadCenter
-from udtc.tools import create_launcher, get_application_desktop_file
+from udtc.network.download_center import DownloadCenter, DownloadItem
+from udtc.tools import create_launcher, get_application_desktop_file, \
+    ChecksumType, Checksum
 from udtc.ui import UI
 
 
@@ -91,10 +92,12 @@ class Eclipse(udtc.frameworks.baseinstaller.BaseInstaller):
             elif arch == 'x86_64':
                 download_url = self.DOWNLOAD_URL_PAT.format(arch='-x86_64',
                                                             suf='')
-            self.download_requests.append((download_url, md5))
+            self.download_requests.append(
+                DownloadItem(download_url, Checksum(ChecksumType.md5, md5)))
             self.start_download_and_install()
 
-        DownloadCenter(urls=[md5_url], on_done=done, download=False)
+        DownloadCenter(urls=[DownloadItem(md5_url, None)], on_done=done,
+                       download=False)
 
     def create_launcher(self):
         """Create the Luna launcher"""

--- a/udtc/tools.py
+++ b/udtc/tools.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License along with
 # this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
-
+from collections import namedtuple
 from contextlib import suppress
+from enum import unique, Enum
 from gettext import gettext as _
 from gi.repository import GLib, Gio
 from glob import glob
@@ -41,6 +42,18 @@ logger = logging.getLogger(__name__)
 _current_arch = None
 _foreign_arch = None
 _version = None
+
+
+@unique
+class ChecksumType(Enum):
+    """Types of supported checksum algorithms."""
+    md5 = "md5"
+    sha1 = "sha1"
+
+
+class Checksum(namedtuple('Checksum', ['checksum_type', 'checksum_value'])):
+    """A combination of checksum algorithm and actual value to check."""
+    pass
 
 
 class Singleton(type):


### PR DESCRIPTION
Here's what I have so far. DownloadCenter no longer takes tuples of (url, md5) but instances of DownloadItem. DownloadItem is a url and optionally a Checksum. Checksum is ChecksumType + value.

Fixed small tests so far.
