### PR TITLE
Added FTP downloading support to the download center.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,9 @@ RUN \
   adduser --disabled-password --gecos "" user && \
   echo user:user | chpasswd && \
 
+# Twisted for a mock FTP server.
+  apt-get install python-twisted-core -y && \
+
 # add certificates
   update-ca-certificates && \
 

--- a/tests/large/__init__.py
+++ b/tests/large/__init__.py
@@ -110,7 +110,7 @@ class LargeFrameworkTests(LoggedTestCase):
         It doesn't fail on the given timeout if stdout is progressing"""
         output = ""
         continue_expect = True
-        while(continue_expect):
+        while continue_expect:
             try:
                 self.child.expect(expect_query, timeout=timeout)
                 continue_expect = False

--- a/tests/medium/__init__.py
+++ b/tests/medium/__init__.py
@@ -21,7 +21,7 @@
 
 import os
 import subprocess
-from ..tools import get_root_dir, get_tools_helper_dir, LoggedTestCase, get_docker_path
+from ..tools import get_root_dir, get_tools_helper_dir, LoggedTestCase, get_docker_path, get_data_dir
 from time import sleep
 from umake import settings
 
@@ -40,14 +40,20 @@ class ContainerTests(LoggedTestCase):
 
         # start the local server at container startup
         if hasattr(self, "hostname"):
+            ftp_redir = hasattr(self, 'ftp')
             command.extend(["-h", self.hostname])
-            runner_cmd += "{} {} 'sudo -E env PATH={} VIRTUAL_ENV={} {} {} {}';".format(
+            runner_cmd += "{} {} 'sudo -E env PATH={} VIRTUAL_ENV={} {} {} {} {}';".format(
                 os.path.join(get_tools_helper_dir(), "run_in_umake_dir_async"),
                 settings.UMAKE_IN_CONTAINER,
                 os.getenv("PATH"), os.getenv("VIRTUAL_ENV"),
                 os.path.join(get_tools_helper_dir(), "run_local_server"),
                 self.port,
-                self.hostname)
+                self.hostname,
+                str(ftp_redir))
+
+            if ftp_redir:
+                runner_cmd += "/usr/bin/twistd ftp -p 21 -r {};".format(os.path.join(get_data_dir(), 'server-content',
+                                                                                 self.hostname))
 
         if hasattr(self, "apt_repo_override_path"):
             runner_cmd += "sudo sh -c 'echo deb file:{} / > /etc/apt/sources.list';sudo apt-get update;".format(

--- a/tests/medium/__init__.py
+++ b/tests/medium/__init__.py
@@ -53,7 +53,7 @@ class ContainerTests(LoggedTestCase):
 
             if ftp_redir:
                 runner_cmd += "/usr/bin/twistd ftp -p 21 -r {};".format(os.path.join(get_data_dir(), 'server-content',
-                                                                                 self.hostname))
+                                                                        self.hostname))
 
         if hasattr(self, "apt_repo_override_path"):
             runner_cmd += "sudo sh -c 'echo deb file:{} / > /etc/apt/sources.list';sudo apt-get update;".format(

--- a/tests/medium/test_ide.py
+++ b/tests/medium/test_ide.py
@@ -57,7 +57,7 @@ class EclipseIDEInContainerFTP(ContainerTests, test_ide.EclipseIDETests):
         super().setUp()
         # override with container path
         self.installed_path = os.path.expanduser("/home/{}/tools/ide/eclipse".format(settings.DOCKER_USER))
-        
+
 
 class IdeaIDEInContainer(ContainerTests, test_ide.IdeaIDETests):
     """This will test the Idea IDE integration inside a container"""

--- a/tests/medium/test_ide.py
+++ b/tests/medium/test_ide.py
@@ -42,6 +42,23 @@ class EclipseIDEInContainer(ContainerTests, test_ide.EclipseIDETests):
         self.installed_path = os.path.expanduser("/home/{}/tools/ide/eclipse".format(settings.DOCKER_USER))
 
 
+class EclipseIDEInContainerFTP(ContainerTests, test_ide.EclipseIDETests):
+    """This will test the Eclipse IDE integration inside a container, involving an FTP server."""
+
+    TIMEOUT_START = 20
+    TIMEOUT_STOP = 10
+
+    def setUp(self):
+        self.hostname = "www.eclipse.org"
+        self.port = "443"
+        self.ftp = True
+        # we reuse the android-studio repo
+        self.apt_repo_override_path = os.path.join(settings.APT_FAKE_REPO_PATH, 'eclipse')
+        super().setUp()
+        # override with container path
+        self.installed_path = os.path.expanduser("/home/{}/tools/ide/eclipse".format(settings.DOCKER_USER))
+        
+
 class IdeaIDEInContainer(ContainerTests, test_ide.IdeaIDETests):
     """This will test the Idea IDE integration inside a container"""
 

--- a/tests/small/test_download_center.py
+++ b/tests/small/test_download_center.py
@@ -343,7 +343,7 @@ class TestDownloadCenter(LoggedTestCase):
     def test_unsupported_protocol(self):
         """Raises an exception when trying to download for an unsupported protocol"""
         filename = "simplefile"
-        url = self.build_server_address(filename).replace('http', 'ftp')
+        url = self.build_server_address(filename).replace('http', 'sftp')
         request = DownloadItem(url, None)
         DownloadCenter([request], self.callback, download=False)
         self.wait_for_callback(self.callback)

--- a/tests/tools/local_server.py
+++ b/tests/tools/local_server.py
@@ -166,7 +166,7 @@ class RequestHandler(SimpleHTTPRequestHandler):
             # keep special ?file= to redirect the query
             if '?file=' in self.path:
                 self.path = self.path.split('?file=', 1)[1]
-                self.path = self.path.replace('&', '?', 1) # Replace the first & with ? to make it valid.
+                self.path = self.path.replace('&', '?', 1)  # Replace the first & with ? to make it valid.
             if RequestHandler.ftp_redir:
                 self.send_response(302)
                 # We need to remove the query parameters, so we actually parse the URL.

--- a/tests/tools/run_local_server
+++ b/tests/tools/run_local_server
@@ -34,9 +34,10 @@ logging.basicConfig(level=logging.DEBUG,
 
 # start a connection
 hostname = sys.argv[2]
+ftp_redir = (sys.argv[3].lower() == 'true') if len(sys.argv) > 3 else False
 server_dir = os.path.join(get_data_dir(), "server-content", hostname)
 use_ssl = "{}.pem".format(hostname)
 if not os.path.isfile(os.path.join(get_data_dir(), use_ssl)):
     use_ssl = False
 
-LocalHttp(server_dir, port=int(sys.argv[1]), use_ssl=use_ssl)
+LocalHttp(server_dir, port=int(sys.argv[1]), use_ssl=use_ssl, ftp_redir=ftp_redir)

--- a/umake/network/ftp_adapter.py
+++ b/umake/network/ftp_adapter.py
@@ -1,0 +1,79 @@
+from collections import namedtuple
+from ftplib import FTP, error_perm
+from queue import Queue
+from threading import Thread
+import urllib.parse
+from requests import Response
+from requests.adapters import BaseAdapter
+import requests.exceptions
+
+
+class FTPAdapter(BaseAdapter):
+    """An FTP adapter for requests. Supports streaming GETs and not much else."""
+
+    @staticmethod
+    def get_connection(hostname, timeout=None):
+        return FTP(host=hostname, timeout=timeout, user='anonymous')
+
+    def send(self, request, stream=False, timeout=None, **kwargs):
+
+        parsed_url = urllib.parse.urlparse(request.url)
+        file_path = parsed_url.path
+
+        # Strip the leading slash, if present.
+        if file_path.startswith('/'):
+            file_path = file_path[1:]
+
+        try:
+            self.conn = self.get_connection(parsed_url.netloc, timeout)
+        except ConnectionRefusedError as exc:
+            # Wrap this in a requests exception.
+            # in requests 2.2.1, ConnectionError does not take keyword args
+            raise requests.exceptions.ConnectionError() from exc
+
+        resp = Response()
+        resp.url = request.url
+
+        try:
+            size = self.conn.size(file_path)
+        except error_perm:
+            resp.status_code = 404
+            return resp
+
+        if stream:
+            # We have to do this in a background thread, since ftplib's and requests' approaches are the opposite:
+            # ftplib is callback based, and requests needs to expose an iterable. (Push vs pull)
+
+            queue = Queue()
+            done_sentinel = object()
+
+            def handle_transfer():
+                # Download all the chunks into a queue, then place a sentinel object into it to signal completion.
+                self.conn.retrbinary('RETR ' + file_path, queue.put)
+                queue.put(done_sentinel)
+
+            Thread(target=handle_transfer).start()
+
+            def stream(amt=8192, decode_content=False):
+                """A generator, yielding chunks from the queue."""
+                while True:
+                    data = queue.get()
+
+                    if data is not done_sentinel:
+                        yield data
+                    else:
+                        return
+
+            Raw = namedtuple('raw', 'stream')
+
+            raw = Raw(stream)
+
+            resp.status_code = 200
+            resp.raw = raw
+            resp.headers['content-length'] = size
+            resp.close = lambda: self.conn.close()
+            return resp
+
+        else:
+            # Not relevant for Ubuntu Make.
+            raise NotImplementedError


### PR DESCRIPTION
I went with adding a special requests transport adapter. I didn't use requests-ftp but wrote our own, which supports streaming, which is what we need for big files. Maybe I'll see about getting this upstream after a little cleaning.

There's a new medium test for this. The Dockerfile installs twisted, and medium tests will run it if a special flag is set. The local HTTP server has a flag whether to redirect all requests to FTP.