### PR TITLE
Fix umake exit status for failed downloads

### DIFF
--- a/tests/large/__init__.py
+++ b/tests/large/__init__.py
@@ -152,6 +152,16 @@ class LargeFrameworkTests(LoggedTestCase):
         self.child.sendline("")
         self.wait_and_no_warn(expect_warn)
 
+    def close_and_check_status(self, exit_status=0):
+        """exit child process and check its exit status"""
+        self.child.close()
+        self.assertEqual(exit_status, self.child.exitstatus)
+
+    def wait_and_close(self, expect_warn=False, exit_status=0):
+        """wait for exiting and check exit status"""
+        self.wait_and_no_warn(expect_warn)
+        self.close_and_check_status(exit_status)
+
     def command(self, commands_to_run):
         """passthrough, return args"""
         return commands_to_run

--- a/tests/large/test_android.py
+++ b/tests/large/test_android.py
@@ -47,7 +47,7 @@ class AndroidStudioTests(LargeFrameworkTests):
         self.expect_and_no_warn("\[I Accept.*\]")  # ensure we have a license question
         self.child.sendline("a")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         # we have an installed launcher, added to the launcher
         self.assertTrue(self.launcher_exists_and_is_pinned(self.desktop_filename))
@@ -64,7 +64,7 @@ class AndroidStudioTests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} android android-studio'.format(UMAKE)))
         self.expect_and_no_warn("Android Studio is already installed.*\[.*\] ")
         self.child.sendline()
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
     def test_no_license_accept_android_studio(self):
         """We don't accept the license (default)"""
@@ -73,6 +73,7 @@ class AndroidStudioTests(LargeFrameworkTests):
         self.child.sendline("")
         self.expect_and_no_warn("\[I Accept.*\]")  # ensure we have a license question
         self.accept_default_and_wait()
+        self.close_and_check_status()
 
         self.assertFalse(self.launcher_exists_and_is_pinned(self.desktop_filename))
 
@@ -102,7 +103,7 @@ class AndroidStudioTests(LargeFrameworkTests):
             self.expect_and_no_warn("\[.*\] ")
             self.child.sendline("a")
             self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-            self.wait_and_no_warn()
+            self.wait_and_close()
 
             # we have an installed launcher, added to the launcher
             self.assertTrue(self.launcher_exists_and_is_pinned(self.desktop_filename))
@@ -130,7 +131,7 @@ class AndroidStudioTests(LargeFrameworkTests):
             self.expect_and_no_warn("\[.*\] ")
             self.child.sendline("a")
             self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-            self.wait_and_no_warn()
+            self.wait_and_close()
 
             # we have an installed launcher, added to the launcher
             self.assertTrue(self.launcher_exists_and_is_pinned(self.desktop_filename))
@@ -163,7 +164,7 @@ class AndroidStudioTests(LargeFrameworkTests):
             self.expect_and_no_warn("\[.*\] ")
             self.child.sendline("a")
             self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-            self.wait_and_no_warn()
+            self.wait_and_close()
 
             # we have an installed launcher, added to the launcher
             self.assertTrue(self.launcher_exists_and_is_pinned(self.desktop_filename))
@@ -178,6 +179,7 @@ class AndroidStudioTests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} android android-studio /tmp/foo'.format(UMAKE)))
         self.expect_and_no_warn("\[I Accept.*\]")  # ensure we have a license as the first question
         self.accept_default_and_wait()
+        self.close_and_check_status()
 
     def test_start_install_on_empty_dir(self):
         """We try to install on an existing empty dir"""
@@ -189,6 +191,7 @@ class AndroidStudioTests(LargeFrameworkTests):
                                                  .format(UMAKE, self.installed_path)))
         self.expect_and_no_warn("\[I Accept.*\]")  # ensure we have a license as the first question
         self.accept_default_and_wait()
+        self.close_and_check_status()
 
         self.assertFalse(self.launcher_exists_and_is_pinned(self.desktop_filename))
 
@@ -204,6 +207,7 @@ class AndroidStudioTests(LargeFrameworkTests):
                                                  .format(UMAKE, self.installed_path)))
         self.expect_and_no_warn("{} isn't an empty directory.*there\? \[.*\] ".format(self.installed_path))
         self.accept_default_and_wait()
+        self.close_and_check_status()
 
         self.assertFalse(self.launcher_exists_and_is_pinned(self.desktop_filename))
 
@@ -220,12 +224,14 @@ class AndroidStudioTests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} android /tmp/foo'.format(UMAKE)))
         self.expect_and_no_warn("\[I Accept.*\]")  # ensure we have a license as the first question
         self.accept_default_and_wait()
+        self.close_and_check_status()
 
     def test_not_default_framework_with_path_without_path_separator(self):
         """Android Studio isn't selected for default framework with path without separator"""
         self.child = pexpect.spawnu(self.command('{} android foo'.format(UMAKE)))
         self.expect_and_no_warn("error: argument framework: invalid choice")
         self.accept_default_and_wait()
+        self.close_and_check_status(exit_status=2)
 
     def test_is_default_framework_with_user_path(self):
         """Android Studio isn't selected for default framework with path without separator"""
@@ -233,6 +239,7 @@ class AndroidStudioTests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} android ~/foo'.format(UMAKE)))
         self.expect_and_no_warn("\[I Accept.*\]")  # ensure we have a license as the first question
         self.accept_default_and_wait()
+        self.close_and_check_status()
 
     def test_removal(self):
         """Remove android studio with default path"""
@@ -242,13 +249,13 @@ class AndroidStudioTests(LargeFrameworkTests):
         self.expect_and_no_warn("\[.*\] ")
         self.child.sendline("a")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
         self.assertTrue(self.launcher_exists_and_is_pinned(self.desktop_filename))
         self.assertTrue(self.path_exists(self.installed_path))
 
         # now, remove it
         self.child = pexpect.spawnu(self.command('{} android android-studio --remove'.format(UMAKE)))
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         self.assertFalse(self.launcher_exists_and_is_pinned(self.desktop_filename))
         self.assertFalse(self.path_exists(self.installed_path))
@@ -260,13 +267,13 @@ class AndroidStudioTests(LargeFrameworkTests):
         self.expect_and_no_warn("\[.*\] ")
         self.child.sendline("a")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
         self.assertTrue(self.launcher_exists_and_is_pinned(self.desktop_filename))
         self.assertTrue(self.path_exists(self.installed_path))
 
         # now, remove it
         self.child = pexpect.spawnu(self.command('{} android android-studio --remove'.format(UMAKE)))
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         self.assertFalse(self.launcher_exists_and_is_pinned(self.desktop_filename))
         self.assertFalse(self.path_exists(self.installed_path))
@@ -276,7 +283,7 @@ class AndroidStudioTests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} android android-studio {} --accept-license'.format(UMAKE,
                                                  self.installed_path)))
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         # we have an installed launcher, added to the launcher
         self.assertTrue(self.launcher_exists_and_is_pinned(self.desktop_filename))
@@ -344,7 +351,7 @@ class AndroidNDKTests(LargeFrameworkTests):
         self.expect_and_no_warn("\[I Accept.*\]")  # ensure we have a license question
         self.child.sendline("a")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         # we have an installed ndk exec
         self.assert_exec_exists()
@@ -359,4 +366,4 @@ class AndroidNDKTests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} android android-ndk'.format(UMAKE)))
         self.expect_and_no_warn("Android NDK is already installed.*\[.*\] ")
         self.child.sendline()
-        self.wait_and_no_warn()
+        self.wait_and_close()

--- a/tests/large/test_android.py
+++ b/tests/large/test_android.py
@@ -311,7 +311,7 @@ class AndroidSDKTests(LargeFrameworkTests):
         self.expect_and_no_warn("\[I Accept.*\]")  # ensure we have a license question
         self.child.sendline("a")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         # we have an installed sdk exec
         self.assert_exec_exists()
@@ -327,7 +327,7 @@ class AndroidSDKTests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} android android-sdk'.format(UMAKE)))
         self.expect_and_no_warn("Android SDK is already installed.*\[.*\] ")
         self.child.sendline()
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
 
 class AndroidNDKTests(LargeFrameworkTests):

--- a/tests/large/test_dart.py
+++ b/tests/large/test_dart.py
@@ -49,7 +49,7 @@ class DartEditorTests(LargeFrameworkTests):
         self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
         self.child.sendline("")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         # we have an installed launcher, added to the launcher and an icon file
         self.assert_exec_exists()
@@ -59,4 +59,4 @@ class DartEditorTests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} dart'.format(UMAKE)))
         self.expect_and_no_warn("Dart SDK is already installed.*\[.*\] ")
         self.child.sendline()
-        self.wait_and_no_warn()
+        self.wait_and_close()

--- a/tests/large/test_games.py
+++ b/tests/large/test_games.py
@@ -45,7 +45,7 @@ class StencylTests(LargeFrameworkTests):
         self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
         self.child.sendline("")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         # we have an installed launcher, added to the launcher
         self.assertTrue(self.launcher_exists_and_is_pinned(self.desktop_filename))
@@ -65,7 +65,7 @@ class StencylTests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} games stencyl'.format(UMAKE)))
         self.expect_and_no_warn("Stencyl is already installed.*\[.*\] ")
         self.child.sendline()
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
 
 class Unity3DTests(LargeFrameworkTests):

--- a/tests/large/test_games.py
+++ b/tests/large/test_games.py
@@ -91,7 +91,7 @@ class Unity3DTests(LargeFrameworkTests):
         self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
         self.child.sendline("")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         # we have an installed launcher, added to the launcher
         self.assertTrue(self.launcher_exists_and_is_pinned(self.desktop_filename))
@@ -112,4 +112,4 @@ class Unity3DTests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} games unity3d'.format(UMAKE)))
         self.expect_and_no_warn("Unity3d is already installed.*\[.*\] ")
         self.child.sendline()
-        self.wait_and_no_warn()
+        self.wait_and_close()

--- a/tests/large/test_go.py
+++ b/tests/large/test_go.py
@@ -62,7 +62,7 @@ class GoTests(LargeFrameworkTests):
         self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
         self.child.sendline("")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         self.assert_exec_exists()
         self.assertTrue(self.is_in_path(self.exec_path))

--- a/tests/large/test_ide.py
+++ b/tests/large/test_ide.py
@@ -54,7 +54,7 @@ class EclipseIDETests(LargeFrameworkTests):
         self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
         self.child.sendline("")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         # we have an installed launcher, added to the launcher and an icon file
         self.assertTrue(self.launcher_exists_and_is_pinned(self.desktop_filename))
@@ -78,7 +78,7 @@ class EclipseIDETests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} ide eclipse'.format(UMAKE)))
         self.expect_and_no_warn("Eclipse is already installed.*\[.*\] ")
         self.child.sendline()
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
 
 class IdeaIDETests(LargeFrameworkTests):
@@ -99,7 +99,7 @@ class IdeaIDETests(LargeFrameworkTests):
         self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
         self.child.sendline("")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         # we have an installed launcher, added to the launcher and an icon file
         self.assertTrue(self.launcher_exists_and_is_pinned(self.desktop_filename))
@@ -117,7 +117,7 @@ class IdeaIDETests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} ide idea'.format(UMAKE)))
         self.expect_and_no_warn("Idea is already installed.*\[.*\] ")
         self.child.sendline()
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
 
 class IdeaUltimateIDETests(LargeFrameworkTests):
@@ -138,7 +138,7 @@ class IdeaUltimateIDETests(LargeFrameworkTests):
         self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
         self.child.sendline("")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         logger.info("Installed, running...")
 
@@ -158,7 +158,7 @@ class IdeaUltimateIDETests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} ide idea-ultimate'.format(UMAKE)))
         self.expect_and_no_warn("Idea Ultimate is already installed.*\[.*\] ")
         self.child.sendline()
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
 
 class PyCharmIDETests(LargeFrameworkTests):
@@ -179,7 +179,7 @@ class PyCharmIDETests(LargeFrameworkTests):
         self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
         self.child.sendline("")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         logger.info("Installed, running...")
 
@@ -199,7 +199,7 @@ class PyCharmIDETests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} ide pycharm'.format(UMAKE)))
         self.expect_and_no_warn("PyCharm is already installed.*\[.*\] ")
         self.child.sendline()
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
 
 class PyCharmEducationalIDETests(LargeFrameworkTests):
@@ -220,7 +220,7 @@ class PyCharmEducationalIDETests(LargeFrameworkTests):
         self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
         self.child.sendline("")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         logger.info("Installed, running...")
 
@@ -240,7 +240,7 @@ class PyCharmEducationalIDETests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} ide pycharm-educational'.format(UMAKE)))
         self.expect_and_no_warn("PyCharm Educational is already installed.*\[.*\] ")
         self.child.sendline()
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
 
 class PyCharmProfessionalIDETests(LargeFrameworkTests):
@@ -261,7 +261,7 @@ class PyCharmProfessionalIDETests(LargeFrameworkTests):
         self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
         self.child.sendline("")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         logger.info("Installed, running...")
 
@@ -281,7 +281,7 @@ class PyCharmProfessionalIDETests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} ide pycharm-professional'.format(UMAKE)))
         self.expect_and_no_warn("PyCharm Professional is already installed.*\[.*\] ")
         self.child.sendline()
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
 
 class RubyMineIDETests(LargeFrameworkTests):
@@ -302,7 +302,7 @@ class RubyMineIDETests(LargeFrameworkTests):
         self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
         self.child.sendline("")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         logger.info("Installed, running...")
 
@@ -322,7 +322,7 @@ class RubyMineIDETests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} ide rubymine'.format(UMAKE)))
         self.expect_and_no_warn("RubyMine is already installed.*\[.*\] ")
         self.child.sendline()
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
 
 class WebStormIDETests(LargeFrameworkTests):
@@ -343,7 +343,7 @@ class WebStormIDETests(LargeFrameworkTests):
         self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
         self.child.sendline("")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         logger.info("Installed, running...")
 
@@ -363,7 +363,7 @@ class WebStormIDETests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} ide webstorm'.format(UMAKE)))
         self.expect_and_no_warn("WebStorm is already installed.*\[.*\] ")
         self.child.sendline()
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
 
 class PhpStormIDETests(LargeFrameworkTests):
@@ -384,7 +384,7 @@ class PhpStormIDETests(LargeFrameworkTests):
         self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
         self.child.sendline("")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         logger.info("Installed, running...")
 
@@ -404,7 +404,7 @@ class PhpStormIDETests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} ide phpstorm'.format(UMAKE)))
         self.expect_and_no_warn("PhpStorm is already installed.*\[.*\] ")
         self.child.sendline()
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
 
 class ArduinoIDETests(LargeFrameworkTests):
@@ -430,7 +430,7 @@ class ArduinoIDETests(LargeFrameworkTests):
         self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
         self.child.sendline("")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         # we have an installed launcher, added to the launcher and an icon file
         self.assertTrue(self.launcher_exists_and_is_pinned(self.desktop_filename))
@@ -449,4 +449,4 @@ class ArduinoIDETests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} ide arduino'.format(UMAKE)))
         self.expect_and_no_warn("Arduino is already installed.*\[.*\] ")
         self.child.sendline()
-        self.wait_and_no_warn()
+        self.wait_and_close()

--- a/tests/large/test_scala.py
+++ b/tests/large/test_scala.py
@@ -63,7 +63,7 @@ class ScalaTests(LargeFrameworkTests):
         self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
         self.child.sendline("")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         self.assert_exec_exists()
         self.assertTrue(self.is_in_path(self.exec_path))

--- a/tests/large/test_web.py
+++ b/tests/large/test_web.py
@@ -66,7 +66,7 @@ class FirefoxDevTests(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} web firefox-dev'.format(UMAKE)))
         self.expect_and_no_warn("Firefox Dev is already installed.*\[.*\] ")
         self.child.sendline()
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
     def test_default_install(self):
         """Install firefox dev from scratch test case"""
@@ -77,7 +77,7 @@ class FirefoxDevTests(LargeFrameworkTests):
         self.expect_and_no_warn("Choose language:")
         self.child.sendline("")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
         self.verify_install(install_language)
 
     def test_arg_language_select_install(self):
@@ -87,7 +87,7 @@ class FirefoxDevTests(LargeFrameworkTests):
         self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
         self.child.sendline("")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
         self.verify_install(install_language)
 
     def test_interactive_language_select_install(self):
@@ -99,16 +99,18 @@ class FirefoxDevTests(LargeFrameworkTests):
         self.expect_and_no_warn("Choose language:")
         self.child.sendline(install_language)
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
         self.verify_install(install_language)
 
     def test_unavailable_language_select_install(self):
+        """Installing Firefox-dev in unavailable language should be rejected"""
         install_language = "ABCdwXYZ"
         self.child = pexpect.spawnu(self.command('{} web firefox-dev --lang={}'.format(UMAKE, install_language)))
         self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
-        self.accept_default_and_wait(expect_warn=True)
-        self.child.close()
-        self.assertEqual(self.child.exitstatus, 1)
+        self.child.sendline("")
+        self.wait_and_close(expect_warn=True, exit_status=1)
+
+        self.assertFalse(self.launcher_exists_and_is_pinned(self.desktop_filename))
 
     def language_file_exists(self, language):
         return self.path_exists(os.path.join(self.installed_path, "dictionaries", "{}.aff".format(language)))
@@ -135,7 +137,7 @@ class VisualStudioCodeTest(LargeFrameworkTests):
         self.expect_and_no_warn("\[I Accept.*\]")  # ensure we have a license question
         self.child.sendline("a")
         self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
-        self.wait_and_no_warn()
+        self.wait_and_close()
 
         # we have an installed launcher, added to the launcher and an icon file
         self.assertTrue(self.launcher_exists_and_is_pinned(self.desktop_filename))
@@ -154,4 +156,4 @@ class VisualStudioCodeTest(LargeFrameworkTests):
         self.child = pexpect.spawnu(self.command('{} web visual-studio-code'.format(UMAKE)))
         self.expect_and_no_warn("Visual Studio Code is already installed.*\[.*\] ")
         self.child.sendline()
-        self.wait_and_no_warn()
+        self.wait_and_close()

--- a/tests/medium/__init__.py
+++ b/tests/medium/__init__.py
@@ -20,9 +20,12 @@
 """Tests for basic CLI commands"""
 
 import os
+import pexpect
 import subprocess
-from ..tools import get_root_dir, get_tools_helper_dir, LoggedTestCase, get_docker_path, get_data_dir
+from ..tools import get_root_dir, get_tools_helper_dir, LoggedTestCase, get_docker_path, get_data_dir, \
+    swap_file_and_restore
 from time import sleep
+from nose.tools import nottest
 
 
 class ContainerTests(LoggedTestCase):
@@ -177,3 +180,14 @@ class ContainerTests(LoggedTestCase):
         command = self.command_as_list(["mkdir", "-p", dir_path, path])
         if not self._exec_command(command)[0]:
             raise BaseException("Couldn't create {} in container".format(path))
+
+    @nottest
+    def bad_download_page_test(self, command, content_file_path):
+        """Helper for running a test to confirm failure on a significantly changed download page."""
+        with swap_file_and_restore(content_file_path):
+            with open(content_file_path, "w") as newfile:
+                newfile.write("foo")
+            self.child = pexpect.spawnu(command)
+            self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
+            self.child.sendline("")
+            self.wait_and_close(expect_warn=True, exit_status=1)

--- a/tests/medium/test_android.py
+++ b/tests/medium/test_android.py
@@ -64,19 +64,11 @@ class AndroidStudioInContainer(ContainerTests, test_android.AndroidStudioTests):
 
     def test_install_with_changed_download_page(self):
         """Installing android studio should fail if download page has significantly changed"""
-        android_studio_file_path = os.path.join(get_data_dir(), "server-content", "developer.android.com",
-                                                "sdk", "index.html")
-        fake_content = "<html></html>"
-        with swap_file_and_restore(android_studio_file_path):
-            with open(android_studio_file_path, "w") as newfile:
-                newfile.write(fake_content)
-            self.child = pexpect.spawnu(self.command('{} android android-studio'.format(UMAKE)))
-            self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
-            self.child.sendline("")
-            self.expect_and_no_warn("Download page changed its syntax or is not parsable", expect_warn=True)
-            self.wait_and_close(exit_status=1)
-
-            self.assertFalse(self.launcher_exists_and_is_pinned(self.desktop_filename))
+        download_page_file_path = os.path.join(get_data_dir(), "server-content", "developer.android.com",
+                                               "sdk", "index.html")
+        umake_command = self.command("{} android android-studio".format(UMAKE))
+        self.bad_download_page_test(umake_command, download_page_file_path)
+        self.assertFalse(self.launcher_exists_and_is_pinned(self.desktop_filename))
 
 
 class AndroidSDKContainer(ContainerTests, test_android.AndroidSDKTests):

--- a/tests/medium/test_android.py
+++ b/tests/medium/test_android.py
@@ -62,6 +62,22 @@ class AndroidStudioInContainer(ContainerTests, test_android.AndroidStudioTests):
             # we have nothing installed
             self.assertFalse(self.launcher_exists_and_is_pinned(self.desktop_filename))
 
+    def test_install_with_changed_download_page(self):
+        """Installing android studio should fail if download page has significantly changed"""
+        android_studio_file_path = os.path.join(get_data_dir(), "server-content", "developer.android.com",
+                                                "sdk", "index.html")
+        fake_content = "<html></html>"
+        with swap_file_and_restore(android_studio_file_path):
+            with open(android_studio_file_path, "w") as newfile:
+                newfile.write(fake_content)
+            self.child = pexpect.spawnu(self.command('{} android android-studio'.format(UMAKE)))
+            self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
+            self.child.sendline("")
+            self.expect_and_no_warn("Download page changed its syntax or is not parsable", expect_warn=True)
+            self.wait_and_close(exit_status=1)
+
+            self.assertFalse(self.launcher_exists_and_is_pinned(self.desktop_filename))
+
 
 class AndroidSDKContainer(ContainerTests, test_android.AndroidSDKTests):
     """This will install Android SDK inside a container"""

--- a/tests/medium/test_android.py
+++ b/tests/medium/test_android.py
@@ -57,6 +57,7 @@ class AndroidStudioInContainer(ContainerTests, test_android.AndroidStudioTests):
             self.child.sendline("a")
             self.expect_and_no_warn([pexpect.EOF, "Corrupted download? Aborting."],
                                     timeout=self.TIMEOUT_INSTALL_PROGRESS, expect_warn=True)
+            self.wait_and_close(exit_status=1)
 
             # we have nothing installed
             self.assertFalse(self.launcher_exists_and_is_pinned(self.desktop_filename))

--- a/tests/medium/test_ide.py
+++ b/tests/medium/test_ide.py
@@ -230,7 +230,7 @@ class ArduinoIDEInContainer(ContainerTests, test_ide.ArduinoIDETests):
             self.child = pexpect.spawnu(self.command('{} ide arduino'.format(UMAKE)))
             self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
             self.child.sendline("")
-            self.expect_and_no_warn("Can't parse the download link", expect_warn=True)
+            self.expect_and_no_warn("Can't parse the download link from", expect_warn=True)
             self.wait_and_close(exit_status=1)
 
             self.assertFalse(self.launcher_exists_and_is_pinned(self.desktop_filename))

--- a/tests/medium/test_web.py
+++ b/tests/medium/test_web.py
@@ -63,7 +63,7 @@ class VisualStudioCodeContainer(ContainerTests, test_web.VisualStudioCodeTest):
 
     def test_install_with_changed_download_page(self):
         """Installing visual studio code should fail if download page has significantly changed"""
-        download_page_file_path = os.path.join(get_data_dir(), "server-content", "code.visualstudio.com", "Download")
+        download_page_file_path = os.path.join(get_data_dir(), "server-content", "code.visualstudio.com", "Docs")
         umake_command = self.command('{} web visual-studio-code'.format(UMAKE))
         self.bad_download_page_test(umake_command, download_page_file_path)
         self.assertFalse(self.launcher_exists_and_is_pinned(self.desktop_filename))

--- a/tests/medium/test_web.py
+++ b/tests/medium/test_web.py
@@ -21,9 +21,8 @@
 
 from . import ContainerTests
 import os
-import pexpect
 from ..large import test_web
-from ..tools import get_data_dir, swap_file_and_restore, UMAKE
+from ..tools import get_data_dir, UMAKE
 
 
 class FirefoxDevContainer(ContainerTests, test_web.FirefoxDevTests):
@@ -43,17 +42,9 @@ class FirefoxDevContainer(ContainerTests, test_web.FirefoxDevTests):
         """Installing firefox developer should fail if download page has significantly changed"""
         download_page_file_path = os.path.join(get_data_dir(), "server-content", "www.mozilla.org", "en-US",
                                                "firefox", "developer", "all")
-        fake_content = "<html></html>"
-        with swap_file_and_restore(download_page_file_path):
-            with open(download_page_file_path, "w") as newfile:
-                newfile.write(fake_content)
-            self.child = pexpect.spawnu(self.command('{} web firefox-dev'.format(UMAKE)))
-            self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
-            self.child.sendline("")
-            self.expect_and_no_warn("Download page changed its syntax or is not parsable", expect_warn=True)
-            self.wait_and_close(exit_status=1)
-
-            self.assertFalse(self.launcher_exists_and_is_pinned(self.desktop_filename))
+        umake_command = self.command('{} web firefox-dev'.format(UMAKE))
+        self.bad_download_page_test(umake_command, download_page_file_path)
+        self.assertFalse(self.launcher_exists_and_is_pinned(self.desktop_filename))
 
 
 class VisualStudioCodeContainer(ContainerTests, test_web.VisualStudioCodeTest):
@@ -73,14 +64,13 @@ class VisualStudioCodeContainer(ContainerTests, test_web.VisualStudioCodeTest):
     def test_install_with_changed_download_page(self):
         """Installing visual studio code should fail if download page has significantly changed"""
         download_page_file_path = os.path.join(get_data_dir(), "server-content", "code.visualstudio.com", "Download")
-        fake_content = "<html></html>"
-        with swap_file_and_restore(download_page_file_path):
-            with open(download_page_file_path, "w") as newfile:
-                newfile.write(fake_content)
-            self.child = pexpect.spawnu(self.command('{} web visual-studio-code'.format(UMAKE)))
-            self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
-            self.child.sendline("")
-            self.expect_and_no_warn("Download page changed its syntax or is not parsable", expect_warn=True)
-            self.wait_and_close(exit_status=1)
+        umake_command = self.command('{} web visual-studio-code'.format(UMAKE))
+        self.bad_download_page_test(umake_command, download_page_file_path)
+        self.assertFalse(self.launcher_exists_and_is_pinned(self.desktop_filename))
 
-            self.assertFalse(self.launcher_exists_and_is_pinned(self.desktop_filename))
+    def test_install_with_changed_license_page(self):
+        """Installing visual studio code should fail if license page has significantly changed"""
+        license_page_file_path = os.path.join(get_data_dir(), "server-content", "code.visualstudio.com", "License")
+        umake_command = self.command('{} web visual-studio-code'.format(UMAKE))
+        self.bad_download_page_test(umake_command, license_page_file_path)
+        self.assertFalse(self.launcher_exists_and_is_pinned(self.desktop_filename))

--- a/umake/frameworks/__init__.py
+++ b/umake/frameworks/__init__.py
@@ -238,7 +238,7 @@ class BaseFramework(metaclass=abc.ABCMeta):
         """Method call to setup the Framework"""
         if not self.is_installable:
             logger.error(_("You can't install that framework on this machine"))
-            UI.return_main_screen()
+            UI.return_main_screen(status_code=1)
 
         if self.need_root_access and os.geteuid() != 0:
             logger.debug("Requesting root access")
@@ -299,7 +299,7 @@ class BaseFramework(metaclass=abc.ABCMeta):
             if args.destdir:
                 message = "You can't specify a destination dir while removing a framework"
                 logger.error(message)
-                UI.return_main_screen()
+                UI.return_main_screen(status_code=1)
             self.remove()
         else:
             install_path = None

--- a/umake/frameworks/baseinstaller.py
+++ b/umake/frameworks/baseinstaller.py
@@ -171,7 +171,7 @@ class BaseInstaller(umake.frameworks.BaseFramework):
         error_msg = result[self.download_page].error
         if error_msg:
             logger.error("An error occurred while downloading {}: {}".format(self.download_page, error_msg))
-            UI.return_main_screen()
+            UI.return_main_screen(status_code=1)
 
         url, checksum = (None, None)
         with StringIO() as license_txt:
@@ -196,7 +196,7 @@ class BaseInstaller(umake.frameworks.BaseFramework):
 
             if url is None or (self.checksum_type and checksum is None):
                 logger.error("Download page changed its syntax or is not parsable")
-                UI.return_main_screen()
+                UI.return_main_screen(status_code=1)
             self.download_requests.append(DownloadItem(url, Checksum(self.checksum_type, checksum)))
 
             if license_txt.getvalue() != "":
@@ -206,7 +206,7 @@ class BaseInstaller(umake.frameworks.BaseFramework):
                                             UI.return_main_screen))
             elif self.expect_license and not self.auto_accept_license:
                 logger.error("We were expecting to find a license on the download page, we didn't.")
-                UI.return_main_screen()
+                UI.return_main_screen(status_code=1)
             else:
                 self.start_download_and_install()
 
@@ -321,7 +321,7 @@ class BaseInstaller(umake.frameworks.BaseFramework):
                 error_detected = True
             fd = self.result_download[url].fd
         if error_detected:
-            UI.return_main_screen()
+            UI.return_main_screen(status_code=1)
 
         self.decompress_and_install(fd)
 
@@ -350,7 +350,7 @@ class BaseInstaller(umake.frameworks.BaseFramework):
                 error_detected = True
             fd.close()
         if error_detected:
-            UI.return_main_screen()
+            UI.return_main_screen(status_code=1)
 
         self.post_install()
 

--- a/umake/frameworks/games.py
+++ b/umake/frameworks/games.py
@@ -158,7 +158,7 @@ class Unity3D(umake.frameworks.baseinstaller.BaseInstaller):
             # chrome sandbox requires this: https//code.google.com/p/chromium/wiki/LinuxSUIDSandbox
             f = executor.submit(_chrome_sandbox_setuid, os.path.join(self.install_path, "Editor", "chrome-sandbox"))
             if not f.result():
-                UI.return_main_screen()
+                UI.return_main_screen(exit_status=1)
         create_launcher(self.desktop_filename, get_application_desktop_file(name=_("Unity3D Editor"),
                         icon_path=os.path.join(self.install_path, "unity-editor-icon.png"),
                         exec=os.path.join(self.install_path, "Editor", "Unity"),

--- a/umake/frameworks/web.py
+++ b/umake/frameworks/web.py
@@ -70,7 +70,7 @@ class FirefoxDev(umake.frameworks.baseinstaller.BaseInstaller):
         error_msg = result[self.download_page].error
         if error_msg:
             logger.error("An error occurred while downloading {}: {}".format(self.download_page, error_msg))
-            UI.return_main_screen()
+            UI.return_main_screen(status_code=1)
 
         arch = platform.machine()
         arg_lang_url = None
@@ -105,12 +105,12 @@ class FirefoxDev(umake.frameworks.baseinstaller.BaseInstaller):
             logger.debug("Selecting {} lang".format(self.arg_lang))
             if not arg_lang_url:
                 logger.error("Could not find a download url for language {}".format(self.arg_lang))
-                UI.return_main_screen(1)
+                UI.return_main_screen(status_code=1)
             self.language_select_callback(arg_lang_url)
         else:
             if not languages:
                 logger.error("Download page changed its syntax or is not parsable")
-                UI.return_main_screen()
+                UI.return_main_screen(status_code=1)
             logger.debug("Check list of installable languages.")
             UI.delayed_display(TextWithChoices(_("Choose language: {}".format(default_label)), languages, True))
 
@@ -169,7 +169,7 @@ class VisualStudioCode(umake.frameworks.baseinstaller.BaseInstaller):
         error_msg = result[self.download_page].error
         if error_msg:
             logger.error("An error occurred while downloading {}: {}".format(self.download_page, error_msg))
-            UI.return_main_screen()
+            UI.return_main_screen(status_code=1)
 
         arch = platform.machine()
         download_re = r'\'linux64\': \'([^\']+)\''
@@ -185,7 +185,7 @@ class VisualStudioCode(umake.frameworks.baseinstaller.BaseInstaller):
 
         if url is None:
             logger.error("Download page changed its syntax or is not parsable")
-            UI.return_main_screen()
+            UI.return_main_screen(status_code=1)
         self.download_requests.append(DownloadItem(url, Checksum(self.checksum_type, None), headers=self.headers))
 
         if not self.auto_accept_license:
@@ -202,7 +202,7 @@ class VisualStudioCode(umake.frameworks.baseinstaller.BaseInstaller):
         error_msg = result[self.license_url].error
         if error_msg:
             logger.error("An error occurred while downloading {}: {}".format(self.license_url, error_msg))
-            UI.return_main_screen()
+            UI.return_main_screen(status_code=1)
 
         with StringIO() as license_txt:
             in_license = False
@@ -223,7 +223,7 @@ class VisualStudioCode(umake.frameworks.baseinstaller.BaseInstaller):
                                             UI.return_main_screen))
             else:
                 logger.error("We were expecting to find a license, we didn't.")
-                UI.return_main_screen()
+                UI.return_main_screen(status_code=1)
 
     def post_install(self):
         """Create the Visual Studio Code launcher"""


### PR DESCRIPTION
Fixes #129 - umake should now exit with the correct status when it fails. All tests now confirm umake's exit code except for those in which umake is terminated by sendcontrol('C'). All but two medium tests pass; the two that fail are "Reinstall android studio on another path (non empty) once installed should remove the first version" and "We prompt if we try to install on an existing directory which isn't empty" but these were already failing for me before my changes.

I only added one test per framework that overloads get_metadata_and_license() although some of them have more than one exit point e.g. visual studio code can also fail if the License page is changed. If needed I can add tests for those as well.

I had to adjust the arduino installer in order to exit it properly for the medium test. We had to confirm soup.find() had returned something other than None before accessing ['href'].