### PR TITLE
Install dir

### DIFF
--- a/tests/large/__init__.py
+++ b/tests/large/__init__.py
@@ -28,7 +28,7 @@ import stat
 import subprocess
 from time import sleep
 from umake.tools import get_icon_path, get_launcher_path, launcher_exists_and_is_pinned, remove_framework_envs_from_user
-from ..tools import LoggedTestCase, get_path_from_desktop_file, is_in_group
+from ..tools import LoggedTestCase, get_path_from_desktop_file, is_in_group, INSTALL_DIR
 
 
 class LargeFrameworkTests(LoggedTestCase):
@@ -40,7 +40,7 @@ class LargeFrameworkTests(LoggedTestCase):
         self.installed_path = ""
         self.framework_name_for_profile = ""
         self.conf_path = os.path.expanduser("~/.config/umake")
-        self.install_base_path = os.path.expanduser("~/.local/share/umake")
+        self.install_base_path = os.path.expanduser("~/{}".format(INSTALL_DIR))
         self.desktop_filename = ""
         self.child = None
         self.additional_dirs = []

--- a/tests/large/__init__.py
+++ b/tests/large/__init__.py
@@ -40,6 +40,7 @@ class LargeFrameworkTests(LoggedTestCase):
         self.installed_path = ""
         self.framework_name_for_profile = ""
         self.conf_path = os.path.expanduser("~/.config/umake")
+        self.install_base_path = os.path.expanduser("~/.local/share/umake")
         self.desktop_filename = ""
         self.child = None
         self.additional_dirs = []

--- a/tests/large/test_android.py
+++ b/tests/large/test_android.py
@@ -216,6 +216,18 @@ class AndroidStudioTests(LargeFrameworkTests):
             self.assertTrue(self.launcher_exists_and_is_pinned(self.desktop_filename))
             self.assert_exec_exists()
 
+    def test_xdg_data_install_path(self):
+        """Install in path specified by XDG_DATA_HOME"""
+        xdg_data_path = "/tmp/foo"
+        self.installed_path = "{}/umake/android/android-studio".format(xdg_data_path)
+        self.child = pexpect.spawnu(self.command('XDG_DATA_HOME={} {} android android-studio'
+                                                 .format(xdg_data_path, UMAKE)))
+        self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
+        self.child.sendline("")
+        self.expect_and_no_warn("\[I Accept.*\]")
+        self.accept_default_and_wait()
+        self.close_and_check_status()
+
     def test_custom_install_path(self):
         """We install android studio in a custom path"""
         # We skip the existing directory prompt

--- a/tests/large/test_android.py
+++ b/tests/large/test_android.py
@@ -36,7 +36,7 @@ class AndroidStudioTests(LargeFrameworkTests):
 
     def setUp(self):
         super().setUp()
-        self.installed_path = os.path.expanduser("~/tools/android/android-studio")
+        self.installed_path = os.path.join(self.install_base_path, "android", "android-studio")
         self.desktop_filename = "android-studio.desktop"
 
     def test_default_android_studio_install(self):
@@ -357,7 +357,7 @@ class AndroidSDKTests(LargeFrameworkTests):
 
     def setUp(self):
         super().setUp()
-        self.installed_path = os.path.expanduser("~/tools/android/android-sdk")
+        self.installed_path = os.path.join(self.install_base_path, "android", "android-sdk")
 
     @property
     def exec_path(self):
@@ -397,7 +397,7 @@ class AndroidNDKTests(LargeFrameworkTests):
 
     def setUp(self):
         super().setUp()
-        self.installed_path = os.path.expanduser("~/tools/android/android-ndk")
+        self.installed_path = os.path.join(self.install_base_path, "android", "android-ndk")
 
     @property
     def exec_path(self):

--- a/tests/large/test_dart.py
+++ b/tests/large/test_dart.py
@@ -37,7 +37,7 @@ class DartEditorTests(LargeFrameworkTests):
 
     def setUp(self):
         super().setUp()
-        self.installed_path = os.path.expanduser("~/tools/dart/dart-sdk")
+        self.installed_path = os.path.join(self.install_base_path, "dart", "dart-sdk")
 
     @property
     def exec_path(self):

--- a/tests/large/test_games.py
+++ b/tests/large/test_games.py
@@ -36,7 +36,7 @@ class StencylTests(LargeFrameworkTests):
 
     def setUp(self):
         super().setUp()
-        self.installed_path = os.path.expanduser("~/tools/games/stencyl")
+        self.installed_path = os.path.join(self.install_base_path, "games", "stencyl")
         self.desktop_filename = "stencyl.desktop"
 
     def test_default_stencyl_install(self):
@@ -77,7 +77,7 @@ class Unity3DTests(LargeFrameworkTests):
 
     def setUp(self):
         super().setUp()
-        self.installed_path = os.path.expanduser("~/tools/games/unity3d")
+        self.installed_path = os.path.join(self.install_base_path, "games", "unity-3d")
         self.desktop_filename = "unity3d-editor.desktop"
 
     def test_default_unity3D_install(self):

--- a/tests/large/test_go.py
+++ b/tests/large/test_go.py
@@ -40,7 +40,7 @@ class GoTests(LargeFrameworkTests):
 
     def setUp(self):
         super().setUp()
-        self.installed_path = os.path.expanduser("~/tools/go/go-lang")
+        self.installed_path = os.path.join(self.install_base_path, "go", "go-lang")
         self.framework_name_for_profile = "Go Lang"
 
     @property

--- a/tests/large/test_ide.py
+++ b/tests/large/test_ide.py
@@ -40,7 +40,7 @@ class EclipseIDETests(LargeFrameworkTests):
 
     def setUp(self):
         super().setUp()
-        self.installed_path = os.path.expanduser("~/tools/ide/eclipse")
+        self.installed_path = os.path.join(self.install_base_path, "ide", "eclipse")
         self.desktop_filename = "eclipse.desktop"
 
     @property
@@ -90,7 +90,7 @@ class IdeaIDETests(LargeFrameworkTests):
 
     def setUp(self):
         super().setUp()
-        self.installed_path = os.path.expanduser("~/tools/ide/idea")
+        self.installed_path = os.path.join(self.install_base_path, "ide", "idea")
         self.desktop_filename = 'jetbrains-idea.desktop'
 
     def test_default_install(self):
@@ -129,7 +129,7 @@ class IdeaUltimateIDETests(LargeFrameworkTests):
 
     def setUp(self):
         super().setUp()
-        self.installed_path = os.path.expanduser("~/tools/ide/idea-ultimate")
+        self.installed_path = os.path.join(self.install_base_path, "ide", "idea-ultimate")
         self.desktop_filename = 'jetbrains-idea.desktop'
 
     def test_default_install(self):
@@ -170,7 +170,7 @@ class PyCharmIDETests(LargeFrameworkTests):
 
     def setUp(self):
         super().setUp()
-        self.installed_path = os.path.expanduser("~/tools/ide/pycharm")
+        self.installed_path = os.path.join(self.install_base_path, "ide", "pycharm")
         self.desktop_filename = 'jetbrains-pycharm.desktop'
 
     def test_default_install(self):
@@ -211,7 +211,7 @@ class PyCharmEducationalIDETests(LargeFrameworkTests):
 
     def setUp(self):
         super().setUp()
-        self.installed_path = os.path.expanduser("~/tools/ide/pycharm-educational")
+        self.installed_path = os.path.join(self.install_base_path, "ide", "pycharm-educational")
         self.desktop_filename = 'jetbrains-pycharm.desktop'
 
     def test_default_install(self):
@@ -252,7 +252,7 @@ class PyCharmProfessionalIDETests(LargeFrameworkTests):
 
     def setUp(self):
         super().setUp()
-        self.installed_path = os.path.expanduser("~/tools/ide/pycharm-professional")
+        self.installed_path = os.path.join(self.install_base_path, "ide", "pycharm-professional")
         self.desktop_filename = 'jetbrains-pycharm.desktop'
 
     def test_default_install(self):
@@ -293,7 +293,7 @@ class RubyMineIDETests(LargeFrameworkTests):
 
     def setUp(self):
         super().setUp()
-        self.installed_path = os.path.expanduser("~/tools/ide/rubymine")
+        self.installed_path = os.path.join(self.install_base_path, "ide", "rubymine")
         self.desktop_filename = 'jetbrains-rubymine.desktop'
 
     def test_default_install(self):
@@ -334,7 +334,7 @@ class WebStormIDETests(LargeFrameworkTests):
 
     def setUp(self):
         super().setUp()
-        self.installed_path = os.path.expanduser("~/tools/ide/webstorm")
+        self.installed_path = os.path.join(self.install_base_path, "ide", "webstorm")
         self.desktop_filename = 'jetbrains-webstorm.desktop'
 
     def test_default_install(self):
@@ -375,7 +375,7 @@ class PhpStormIDETests(LargeFrameworkTests):
 
     def setUp(self):
         super().setUp()
-        self.installed_path = os.path.expanduser("~/tools/ide/phpstorm")
+        self.installed_path = os.path.join(self.install_base_path, "ide", "phpstorm")
         self.desktop_filename = 'jetbrains-phpstorm.desktop'
 
     def test_default_install(self):
@@ -416,7 +416,7 @@ class ArduinoIDETests(LargeFrameworkTests):
 
     def setUp(self):
         super().setUp()
-        self.installed_path = os.path.expanduser("~/tools/ide/arduino")
+        self.installed_path = os.path.join(self.install_base_path, "ide", "arduino")
         self.desktop_filename = "arduino.desktop"
 
     @property

--- a/tests/large/test_scala.py
+++ b/tests/large/test_scala.py
@@ -41,7 +41,7 @@ class ScalaTests(LargeFrameworkTests):
 
     def setUp(self):
         super().setUp()
-        self.installed_path = os.path.expanduser("~/tools/scala/scala-lang")
+        self.installed_path = os.path.join(self.install_base_path, "scala", "scala-lang")
         self.framework_name_for_profile = "Scala Lang"
 
     @property

--- a/tests/large/test_web.py
+++ b/tests/large/test_web.py
@@ -39,7 +39,7 @@ class FirefoxDevTests(LargeFrameworkTests):
 
     def setUp(self):
         super().setUp()
-        self.installed_path = os.path.expanduser("~/tools/web/firefox-dev")
+        self.installed_path = os.path.join(self.install_base_path, "web", "firefox-dev")
         self.desktop_filename = "firefox-developer.desktop"
 
     @property
@@ -125,7 +125,7 @@ class VisualStudioCodeTest(LargeFrameworkTests):
 
     def setUp(self):
         super().setUp()
-        self.installed_path = os.path.expanduser("~/tools/web/visual-studio-code")
+        self.installed_path = os.path.join(self.install_base_path, "web", "visual-studio-code")
         self.desktop_filename = "visual-studio-code.desktop"
 
     def test_default_install(self):

--- a/tests/medium/__init__.py
+++ b/tests/medium/__init__.py
@@ -23,7 +23,7 @@ import os
 import pexpect
 import subprocess
 from ..tools import get_root_dir, get_tools_helper_dir, LoggedTestCase, get_docker_path, get_data_dir, \
-    swap_file_and_restore
+    swap_file_and_restore, INSTALL_DIR
 from time import sleep
 from nose.tools import nottest
 
@@ -41,7 +41,7 @@ class ContainerTests(LoggedTestCase):
         super().setUp()  # this will call other parents of ContainerTests ancestors, like LargeFrameworkTests
         self.in_container = True
         self.umake_path = get_root_dir()
-        self.install_base_path = os.path.expanduser("/home/{}/.local/share/umake".format(self.DOCKER_USER))
+        self.install_base_path = os.path.expanduser("/home/{}/{}".format(self.DOCKER_USER, INSTALL_DIR))
         self.image_name = self.DOCKER_TESTIMAGE
         command = [get_docker_path(), "run"]
         runner_cmd = "mkdir -p {}; ln -s {}/ {};".format(os.path.dirname(get_root_dir()), self.UMAKE_IN_CONTAINER,

--- a/tests/medium/__init__.py
+++ b/tests/medium/__init__.py
@@ -41,6 +41,7 @@ class ContainerTests(LoggedTestCase):
         super().setUp()  # this will call other parents of ContainerTests ancestors, like LargeFrameworkTests
         self.in_container = True
         self.umake_path = get_root_dir()
+        self.install_base_path = os.path.expanduser("/home/{}/.local/share/umake".format(self.DOCKER_USER))
         self.image_name = self.DOCKER_TESTIMAGE
         command = [get_docker_path(), "run"]
         runner_cmd = "mkdir -p {}; ln -s {}/ {};".format(os.path.dirname(get_root_dir()), self.UMAKE_IN_CONTAINER,

--- a/tests/medium/test_android.py
+++ b/tests/medium/test_android.py
@@ -39,7 +39,7 @@ class AndroidStudioInContainer(ContainerTests, test_android.AndroidStudioTests):
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'android')
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/android/android-studio".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "android", "android-studio")
 
     # additional test with fake md5sum
     def test_android_studio_install_with_wrong_md5sum(self):
@@ -80,7 +80,7 @@ class AndroidSDKContainer(ContainerTests, test_android.AndroidSDKTests):
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'android')
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/android/android-sdk".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "android", "android-sdk")
 
 
 class AndroidNDKContainer(ContainerTests, test_android.AndroidNDKTests):
@@ -92,4 +92,4 @@ class AndroidNDKContainer(ContainerTests, test_android.AndroidNDKTests):
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'android')
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/android/android-ndk".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "android", "android-ndk")

--- a/tests/medium/test_dart.py
+++ b/tests/medium/test_dart.py
@@ -33,7 +33,7 @@ class DartInContainer(ContainerTests, test_dart.DartEditorTests):
         self.port = "443"
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/dart/dart-sdk".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "dart", "dart-sdk")
 
     def test_install_with_changed_version_page(self):
         """Installing dart sdk should fail if version page has significantly changed"""

--- a/tests/medium/test_games.py
+++ b/tests/medium/test_games.py
@@ -36,7 +36,7 @@ class StencylInContainer(ContainerTests, test_games.StencylTests):
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'stencyl')
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/games/stencyl".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "games", "stencyl")
 
 
 class Unity3DInContainer(ContainerTests, test_games.Unity3DTests):
@@ -51,4 +51,4 @@ class Unity3DInContainer(ContainerTests, test_games.Unity3DTests):
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'unity3d')
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/games/unity3d".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "games", "unity3d")

--- a/tests/medium/test_go.py
+++ b/tests/medium/test_go.py
@@ -32,4 +32,4 @@ class GoInContainer(ContainerTests, test_go.GoTests):
         self.port = "443"
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/go/go-lang".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "go", "go-lang")

--- a/tests/medium/test_ide.py
+++ b/tests/medium/test_ide.py
@@ -40,7 +40,7 @@ class EclipseIDEInContainer(ContainerTests, test_ide.EclipseIDETests):
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'eclipse')
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/ide/eclipse".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "ide", "eclipse")
 
 
 class EclipseIDEInContainerFTP(ContainerTests, test_ide.EclipseIDETests):
@@ -57,7 +57,7 @@ class EclipseIDEInContainerFTP(ContainerTests, test_ide.EclipseIDETests):
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'eclipse')
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/ide/eclipse".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "ide", "eclipse")
 
 
 class IdeaIDEInContainer(ContainerTests, test_ide.IdeaIDETests):
@@ -73,7 +73,7 @@ class IdeaIDEInContainer(ContainerTests, test_ide.IdeaIDETests):
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'android')
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/ide/idea".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "ide", "idea")
 
     # This actually tests the code in BaseJetBrains
     def test_install_with_changed_download_page(self):
@@ -98,7 +98,7 @@ class IdeaUltimateIDEInContainer(ContainerTests, test_ide.IdeaUltimateIDETests):
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'android')
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/ide/idea-ultimate".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "ide", "idea-ultimate")
 
 
 class PyCharmIDEInContainer(ContainerTests, test_ide.PyCharmIDETests):
@@ -114,7 +114,7 @@ class PyCharmIDEInContainer(ContainerTests, test_ide.PyCharmIDETests):
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'android')
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/ide/pycharm".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "ide", "pycharm")
 
 
 class PyCharmEducationalIDEInContainer(ContainerTests, test_ide.PyCharmEducationalIDETests):
@@ -130,7 +130,7 @@ class PyCharmEducationalIDEInContainer(ContainerTests, test_ide.PyCharmEducation
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'android')
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/ide/pycharm-educational".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "ide", "pycharm-educational")
 
 
 class PyCharmProfessionalIDEInContainer(ContainerTests, test_ide.PyCharmProfessionalIDETests):
@@ -146,7 +146,7 @@ class PyCharmProfessionalIDEInContainer(ContainerTests, test_ide.PyCharmProfessi
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'android')
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/ide/pycharm-professional".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "ide", "pycharm-professional")
 
 
 class RubyMineIDEInContainer(ContainerTests, test_ide.RubyMineIDETests):
@@ -162,7 +162,7 @@ class RubyMineIDEInContainer(ContainerTests, test_ide.RubyMineIDETests):
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'android')
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/ide/rubymine".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "ide", "rubymine")
 
 
 class WebStormIDEInContainer(ContainerTests, test_ide.WebStormIDETests):
@@ -178,7 +178,7 @@ class WebStormIDEInContainer(ContainerTests, test_ide.WebStormIDETests):
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'android')
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/ide/webstorm".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "ide", "webstorm")
 
 
 class PhpStormIDEInContainer(ContainerTests, test_ide.PhpStormIDETests):
@@ -194,7 +194,7 @@ class PhpStormIDEInContainer(ContainerTests, test_ide.PhpStormIDETests):
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'android')
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/ide/phpstorm".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "ide", "phpstorm")
 
 
 class ArduinoIDEInContainer(ContainerTests, test_ide.ArduinoIDETests):
@@ -209,7 +209,7 @@ class ArduinoIDEInContainer(ContainerTests, test_ide.ArduinoIDETests):
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'arduino')
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/ide/arduino".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "ide", "arduino")
 
     def test_install_with_changed_download_page(self):
         """Installing arduino ide should fail if download page has significantly changed"""

--- a/tests/medium/test_scala.py
+++ b/tests/medium/test_scala.py
@@ -34,4 +34,4 @@ class ScalaInContainer(ContainerTests, test_scala.ScalaTests):
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'scala')
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/scala/scala-lang".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "scala", "scala-lang")

--- a/tests/medium/test_web.py
+++ b/tests/medium/test_web.py
@@ -36,7 +36,7 @@ class FirefoxDevContainer(ContainerTests, test_web.FirefoxDevTests):
         self.port = "443"
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/web/firefox-dev".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "web", "firefox-dev")
 
     def test_install_with_changed_download_page(self):
         """Installing firefox developer should fail if download page has significantly changed"""
@@ -59,7 +59,7 @@ class VisualStudioCodeContainer(ContainerTests, test_web.VisualStudioCodeTest):
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'vscode')
         super().setUp()
         # override with container path
-        self.installed_path = os.path.expanduser("/home/{}/tools/web/visual-studio-code".format(self.DOCKER_USER))
+        self.installed_path = os.path.join(self.install_base_path, "web", "visual-studio-code")
 
     def test_install_with_changed_download_page(self):
         """Installing visual studio code should fail if download page has significantly changed"""

--- a/tests/small/test_frameworks_loader.py
+++ b/tests/small/test_frameworks_loader.py
@@ -27,7 +27,7 @@ import shutil
 import sys
 import tempfile
 from ..data.testframeworks.uninstantiableframework import Uninstantiable, InheritedFromUninstantiable
-from ..tools import get_data_dir, change_xdg_path, patchelem, LoggedTestCase
+from ..tools import get_data_dir, change_xdg_path, patchelem, LoggedTestCase, INSTALL_DIR
 import umake
 from umake import frameworks
 from umake.frameworks.baseinstaller import BaseInstaller
@@ -219,12 +219,12 @@ class TestFrameworkLoader(BaseFrameworkLoader):
     def test_default_install_path(self):
         """Default install path is what we expect, based on category-and framework prog_name"""
         self.assertEqual(self.categoryA.frameworks["framework-b"].install_path,
-                         os.path.expanduser("~/.local/share/umake/category-a/framework-b"))
+                         os.path.expanduser("~/{}/category-a/framework-b".format(INSTALL_DIR)))
 
     def test_specified_at_load_install_path(self):
         """Default install path is overriden by framework specified install path at load time"""
         self.assertEqual(self.categoryA.frameworks["framework-a"].install_path,
-                         os.path.expanduser("~/.local/share/umake/custom/frameworka"))
+                         os.path.expanduser("~/{}/custom/frameworka".format(INSTALL_DIR)))
 
     def test_no_restriction_installable_framework(self):
         """Framework with an no arch or version restriction is installable"""
@@ -461,7 +461,7 @@ class TestFrameworkLoaderWithValidConfig(BaseFrameworkLoader):
                          "/home/didrocks/foo/bar/android-studio")
         # isn't in the config
         self.assertEqual(self.CategoryHandler.categories['category-c'].frameworks["framework-a"].install_path,
-                         os.path.expanduser("~/.local/share/umake/category-c/framework-a"))
+                         os.path.expanduser("~/{}/category-c/framework-a".format(INSTALL_DIR)))
 
 
 class TestFrameworkLoaderSaveConfig(BaseFrameworkLoader):
@@ -502,7 +502,7 @@ class TestFrameworkLoaderSaveConfig(BaseFrameworkLoader):
                          {'frameworks': {
                              'category-a': {
                                  'framework-b': {
-                                     'path': os.path.expanduser('~/.local/share/umake/category-a/framework-b')
+                                     'path': os.path.expanduser('~/{}/category-a/framework-b'.format(INSTALL_DIR))
                                  }}}})
 
     def test_call_setup_save_and_then_mark_in_config_tweaked_path(self):
@@ -523,7 +523,7 @@ class TestFrameworkLoaderSaveConfig(BaseFrameworkLoader):
         """Calling remove_from_config remove a framework from the config"""
         ConfigHandler().config = {'frameworks': {
             'category-a': {
-                'framework-b': {'path': os.path.expanduser('~/.local/share/umake/category-a/framework-b')}
+                'framework-b': {'path': os.path.expanduser('~/{}/category-a/framework-b'.format(INSTALL_DIR))}
             }}}
         self.categoryA.frameworks["framework-b"].remove_from_config()
 
@@ -533,11 +533,11 @@ class TestFrameworkLoaderSaveConfig(BaseFrameworkLoader):
         """Calling remove_from_config remove a framework from the config but keep others"""
         ConfigHandler().config = {'frameworks': {
             'category-a': {
-                'framework-b': {'path': os.path.expanduser('~/.local/share/umake/category-a/framework-b')},
-                'framework-c': {'path': os.path.expanduser('~/.local/share/umake/category-a/framework-c')}
+                'framework-b': {'path': os.path.expanduser('~/{}/category-a/framework-b'.format(INSTALL_DIR))},
+                'framework-c': {'path': os.path.expanduser('~/{}/category-a/framework-c'.format(INSTALL_DIR))}
             },
             'category-b': {
-                'framework-b': {'path': os.path.expanduser('~/.local/share/umake/category-a/framework-b')}
+                'framework-b': {'path': os.path.expanduser('~/{}/category-a/framework-b'.format(INSTALL_DIR))}
             }}}
         self.categoryA.frameworks["framework-b"].remove_from_config()
 
@@ -545,11 +545,11 @@ class TestFrameworkLoaderSaveConfig(BaseFrameworkLoader):
                          {'frameworks': {
                              'category-a': {
                                  'framework-c': {
-                                     'path': os.path.expanduser('~/.local/share/umake/category-a/framework-c')
+                                     'path': os.path.expanduser('~/{}/category-a/framework-c'.format(INSTALL_DIR))
                                  }},
                              'category-b': {
                                  'framework-b': {
-                                     'path': os.path.expanduser('~/.local/share/umake/category-a/framework-b')
+                                     'path': os.path.expanduser('~/{}/category-a/framework-b'.format(INSTALL_DIR))
                                  }}}})
 
 

--- a/tests/small/test_frameworks_loader.py
+++ b/tests/small/test_frameworks_loader.py
@@ -219,12 +219,12 @@ class TestFrameworkLoader(BaseFrameworkLoader):
     def test_default_install_path(self):
         """Default install path is what we expect, based on category-and framework prog_name"""
         self.assertEqual(self.categoryA.frameworks["framework-b"].install_path,
-                         os.path.expanduser("~/tools/category-a/framework-b"))
+                         os.path.expanduser("~/.local/share/umake/category-a/framework-b"))
 
     def test_specified_at_load_install_path(self):
         """Default install path is overriden by framework specified install path at load time"""
         self.assertEqual(self.categoryA.frameworks["framework-a"].install_path,
-                         os.path.expanduser("~/tools/custom/frameworka"))
+                         os.path.expanduser("~/.local/share/umake/custom/frameworka"))
 
     def test_no_restriction_installable_framework(self):
         """Framework with an no arch or version restriction is installable"""
@@ -461,7 +461,7 @@ class TestFrameworkLoaderWithValidConfig(BaseFrameworkLoader):
                          "/home/didrocks/foo/bar/android-studio")
         # isn't in the config
         self.assertEqual(self.CategoryHandler.categories['category-c'].frameworks["framework-a"].install_path,
-                         os.path.expanduser("~/tools/category-c/framework-a"))
+                         os.path.expanduser("~/.local/share/umake/category-c/framework-a"))
 
 
 class TestFrameworkLoaderSaveConfig(BaseFrameworkLoader):
@@ -501,8 +501,9 @@ class TestFrameworkLoaderSaveConfig(BaseFrameworkLoader):
         self.assertEqual(ConfigHandler().config,
                          {'frameworks': {
                              'category-a': {
-                                 'framework-b': {'path': os.path.expanduser('~/tools/category-a/framework-b')}
-                             }}})
+                                 'framework-b': {
+                                     'path': os.path.expanduser('~/.local/share/umake/category-a/framework-b')
+                                 }}}})
 
     def test_call_setup_save_and_then_mark_in_config_tweaked_path(self):
         """Calling mark_in_config with a custom install path save it in the configuration"""
@@ -522,7 +523,7 @@ class TestFrameworkLoaderSaveConfig(BaseFrameworkLoader):
         """Calling remove_from_config remove a framework from the config"""
         ConfigHandler().config = {'frameworks': {
             'category-a': {
-                'framework-b': {'path': os.path.expanduser('~/tools/category-a/framework-b')}
+                'framework-b': {'path': os.path.expanduser('~/.local/share/umake/category-a/framework-b')}
             }}}
         self.categoryA.frameworks["framework-b"].remove_from_config()
 
@@ -532,22 +533,24 @@ class TestFrameworkLoaderSaveConfig(BaseFrameworkLoader):
         """Calling remove_from_config remove a framework from the config but keep others"""
         ConfigHandler().config = {'frameworks': {
             'category-a': {
-                'framework-b': {'path': os.path.expanduser('~/tools/category-a/framework-b')},
-                'framework-c': {'path': os.path.expanduser('~/tools/category-a/framework-c')}
+                'framework-b': {'path': os.path.expanduser('~/.local/share/umake/category-a/framework-b')},
+                'framework-c': {'path': os.path.expanduser('~/.local/share/umake/category-a/framework-c')}
             },
             'category-b': {
-                'framework-b': {'path': os.path.expanduser('~/tools/category-a/framework-b')}
+                'framework-b': {'path': os.path.expanduser('~/.local/share/umake/category-a/framework-b')}
             }}}
         self.categoryA.frameworks["framework-b"].remove_from_config()
 
         self.assertEqual(ConfigHandler().config,
                          {'frameworks': {
                              'category-a': {
-                                 'framework-c': {'path': os.path.expanduser('~/tools/category-a/framework-c')}
-                             },
+                                 'framework-c': {
+                                     'path': os.path.expanduser('~/.local/share/umake/category-a/framework-c')
+                                 }},
                              'category-b': {
-                                 'framework-b': {'path': os.path.expanduser('~/tools/category-a/framework-b')}
-                             }}})
+                                 'framework-b': {
+                                     'path': os.path.expanduser('~/.local/share/umake/category-a/framework-b')
+                                 }}}})
 
 
 class TestFrameworkLoadOnDemandLoader(BaseFrameworkLoader):

--- a/tests/small/test_tools.py
+++ b/tests/small/test_tools.py
@@ -31,7 +31,7 @@ import tempfile
 from textwrap import dedent
 from time import time
 import threading
-from ..tools import change_xdg_path, get_data_dir, LoggedTestCase
+from ..tools import change_xdg_path, get_data_dir, LoggedTestCase, INSTALL_DIR
 from umake import settings, tools
 from umake.tools import ConfigHandler, Singleton, get_current_arch, get_foreign_archs, get_current_ubuntu_version,\
     create_launcher, launcher_exists_and_is_pinned, launcher_exists, get_icon_path, get_launcher_path, copy_icon
@@ -396,13 +396,13 @@ class TestLauncherIcons(LoggedTestCase):
                Version=1.0
                Type=Application
                Name=Android Studio
-               Icon=/home/didrocks/.local/share/umake/android-studio/bin/studio.png
-               Exec="/home/didrocks/.local/share/umake/android-studio/bin/studio.sh" %f
+               Icon=/home/didrocks/{install_dir}/android-studio/bin/studio.png
+               Exec="/home/didrocks/{install_dir}/android-studio/bin/studio.sh" %f
                Comment=Develop with pleasure!
                Categories=Development;IDE;
                Terminal=false
                StartupWMClass=jetbrains-android-studio
-               """)
+               """.format(install_dir=INSTALL_DIR))
 
     def write_desktop_file(self, filename):
         """Write a dummy filename to the applications dir and return filepath"""
@@ -437,13 +437,13 @@ class TestLauncherIcons(LoggedTestCase):
                Version=1.0
                Type=Application
                Name=Android Studio 2
-               Icon=/home/didrocks/.local/share/umake/android-studio/bin/idea2.png
-               Exec="/home/didrocks/.local/share/umake/android-studio/bin/studio2.sh" %f
+               Icon=/home/didrocks/{install_dir}/android-studio/bin/idea2.png
+               Exec="/home/didrocks/{install_dir}/android-studio/bin/studio2.sh" %f
                Comment=Develop with pleasure!
                Categories=Development;IDE;
                Terminal=false
                StartupWMClass=jetbrains-android-studio
-               """)
+               """.format(install_dir=INSTALL_DIR))
         create_launcher("foo.desktop", new_content)
 
         self.assertTrue(os.path.exists(get_launcher_path("foo.desktop")))

--- a/tests/small/test_tools.py
+++ b/tests/small/test_tools.py
@@ -396,8 +396,8 @@ class TestLauncherIcons(LoggedTestCase):
                Version=1.0
                Type=Application
                Name=Android Studio
-               Icon=/home/didrocks/tools/android-studio/bin/studio.png
-               Exec="/home/didrocks/tools/android-studio/bin/studio.sh" %f
+               Icon=/home/didrocks/.local/share/umake/android-studio/bin/studio.png
+               Exec="/home/didrocks/.local/share/umake/android-studio/bin/studio.sh" %f
                Comment=Develop with pleasure!
                Categories=Development;IDE;
                Terminal=false
@@ -437,8 +437,8 @@ class TestLauncherIcons(LoggedTestCase):
                Version=1.0
                Type=Application
                Name=Android Studio 2
-               Icon=/home/didrocks/tools/android-studio/bin/idea2.png
-               Exec="/home/didrocks/tools/android-studio/bin/studio2.sh" %f
+               Icon=/home/didrocks/.local/share/umake/android-studio/bin/idea2.png
+               Exec="/home/didrocks/.local/share/umake/android-studio/bin/studio2.sh" %f
                Comment=Develop with pleasure!
                Categories=Development;IDE;
                Terminal=false

--- a/tests/tools/__init__.py
+++ b/tests/tools/__init__.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 
 DOCKER = None
 UMAKE = "umake"
+INSTALL_DIR = ".local/share/umake"
 
 
 class LoggedTestCase(TestCase):

--- a/umake/settings.py
+++ b/umake/settings.py
@@ -18,8 +18,9 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 import os
+from xdg.BaseDirectory import xdg_data_home
 
-DEFAULT_INSTALL_TOOLS_PATH = os.path.expanduser(os.path.join("~", "tools"))
+DEFAULT_INSTALL_TOOLS_PATH = os.path.expanduser(os.path.join(xdg_data_home, "umake"))
 OLD_CONFIG_FILENAME = "udtc"
 CONFIG_FILENAME = "umake"
 LSB_RELEASE_FILE = "/etc/lsb-release"


### PR DESCRIPTION
This PR changes default install directory to $XDG_DATA_HOME/umake (#81). All paths used in tests have been changed to ~/.local/share/umake and a separate test has been added to confirm installation with $XDG_DATA_HOME set - similar to the existing test custom install path. 

For the new test, I could not think of a more elegant way to set an environment variable in a running container so I simply used /bin/bash -c "export $XDG_DATA_HOME && /bin/umake"'. This required changing the run_in_umake_dir script to not strip the quotations - and then make changes accordingly.

I should mention that I have not been able to rerun all of the large tests due a rather slow Internet connection.