### PR TITLE
Use NDK_ROOT instead of ANDROID_NDK to point to the Android NDK

### DIFF
--- a/tests/large/test_android.py
+++ b/tests/large/test_android.py
@@ -435,7 +435,7 @@ class AndroidNDKTests(LargeFrameworkTests):
 
         # we have an installed ndk exec
         self.assert_exec_exists()
-        cmd_list = ["echo $ANDROID_NDK"]
+        cmd_list = ["echo $NDK_ROOT"]
         if not self.in_container:
             relogging_command = ["bash", "-l", "-c"]
             relogging_command.extend(cmd_list)

--- a/umake/frameworks/android.py
+++ b/umake/frameworks/android.py
@@ -165,7 +165,7 @@ class AndroidNDK(umake.frameworks.baseinstaller.BaseInstaller):
 
     def post_install(self):
         """Add necessary environment variables"""
-        add_env_to_user(self.name, {"ANDROID_NDK": {"value": self.install_path, "keep": False}})
+        add_env_to_user(self.name, {"NDK_ROOT": {"value": self.install_path, "keep": False}})
 
         # print wiki page message
         UI.display(DisplayMessage("NDK installed in {}. More information on how to use it on {}".format(


### PR DESCRIPTION
The official environment variable to use is NDK_ROOT.