### PR TITLE
Add manpage that is generated from the --help text

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,6 +22,7 @@ Build-Depends: debhelper (>= 9),
                python3-xdg,
                dbus-x11,
                fakeroot,
+               help2man,
 Maintainer: Didier Roche <didrocks@ubuntu.com>
 Standards-Version: 3.9.6
 X-Python3-Version: >= 3.4

--- a/debian/rules
+++ b/debian/rules
@@ -7,3 +7,12 @@
 
 override_dh_auto_test:
 	./runtests pep8 small
+
+override_dh_installman:
+	help2man -n "Deploy and setup developers environment easily on ubuntu" -o debian/umake.1 bin/umake
+	sed -i s/+unknown//g debian/umake.1
+	dh_installman
+
+override_dh_clean:
+	rm -f debian/umake.1
+	dh_clean

--- a/debian/ubuntu-make.manpages
+++ b/debian/ubuntu-make.manpages
@@ -1,0 +1,1 @@
+debian/umake.1


### PR DESCRIPTION
Resolves https://github.com/ubuntu/ubuntu-make/issues/98

Not fully tested yet, but it should work (I am new to this though, so who knows). Either way, I'll fully test it when I wake up. 