### PR TITLE
Add updated openjdk

### DIFF
--- a/umake/frameworks/android.py
+++ b/umake/frameworks/android.py
@@ -79,7 +79,7 @@ class AndroidStudio(umake.frameworks.baseinstaller.BaseInstaller):
     def __init__(self, category):
         super().__init__(name="Android Studio", description=_("Android Studio (default)"), is_category_default=True,
                          category=category, only_on_archs=_supported_archs, expect_license=True,
-                         packages_requirements=["openjdk-7-jdk", "libncurses5:i386", "libstdc++6:i386", "zlib1g:i386",
+                         packages_requirements=["openjdk-latest", "libncurses5:i386", "libstdc++6:i386", "zlib1g:i386",
                                                 "jayatana"],
                          download_page="https://developer.android.com/sdk/index.html",
                          checksum_type=ChecksumType.sha1,
@@ -110,7 +110,7 @@ class AndroidSDK(umake.frameworks.baseinstaller.BaseInstaller):
     def __init__(self, category):
         super().__init__(name="Android SDK", description=_("Android SDK"),
                          category=category, only_on_archs=_supported_archs, expect_license=True,
-                         packages_requirements=["openjdk-7-jdk", "libncurses5:i386", "libstdc++6:i386", "zlib1g:i386",
+                         packages_requirements=["openjdk-latest", "libncurses5:i386", "libstdc++6:i386", "zlib1g:i386",
                                                 "jayatana"],
                          download_page="https://developer.android.com/sdk/index.html",
                          checksum_type=ChecksumType.sha1,

--- a/umake/frameworks/ide.py
+++ b/umake/frameworks/ide.py
@@ -184,7 +184,7 @@ class EclipseJava(BaseEclipse):
                          dir_to_decompress_in_tarball='eclipse',
                          desktop_filename='eclipse-java.desktop',
                          category=category, only_on_archs=['i386', 'amd64'],
-                         packages_requirements=['openjdk-7-jdk'],
+                         packages_requirements=["openjdk-latest"],
                          icon_filename='java.png')
 
 
@@ -199,7 +199,7 @@ class EclipsePHP(BaseEclipse):
                          dir_to_decompress_in_tarball='eclipse',
                          desktop_filename='eclipse-php.desktop',
                          category=category, only_on_archs=['i386', 'amd64'],
-                         packages_requirements=['openjdk-7-jdk'],
+                         packages_requirements=['openjdk-latest'],
                          icon_filename='php.png')
 
 
@@ -214,7 +214,7 @@ class EclipseCPP(BaseEclipse):
                          dir_to_decompress_in_tarball='eclipse',
                          desktop_filename='eclipse-cpp.desktop',
                          category=category, only_on_archs=['i386', 'amd64'],
-                         packages_requirements=['openjdk-7-jdk'],
+                         packages_requirements=['openjdk-latest'],
                          icon_filename='cdt.png')
 
 
@@ -302,7 +302,7 @@ class PyCharm(BaseJetBrains):
                          category=category, only_on_archs=['i386', 'amd64'],
                          dir_to_decompress_in_tarball='pycharm-community-*',
                          desktop_filename='jetbrains-pycharm.desktop',
-                         packages_requirements=['openjdk-7-jdk', 'jayatana'],
+                         packages_requirements=['openjdk-latest', 'jayatana'],
                          icon_filename='pycharm.png')
 
 
@@ -317,7 +317,7 @@ class PyCharmEducational(BaseJetBrains):
                          category=category, only_on_archs=['i386', 'amd64'],
                          dir_to_decompress_in_tarball='pycharm-edu*',
                          desktop_filename='jetbrains-pycharm.desktop',
-                         packages_requirements=['openjdk-7-jdk', 'jayatana'],
+                         packages_requirements=['openjdk-latest', 'jayatana'],
                          icon_filename='pycharm.png')
 
 
@@ -332,7 +332,7 @@ class PyCharmProfessional(BaseJetBrains):
                          category=category, only_on_archs=['i386', 'amd64'],
                          dir_to_decompress_in_tarball='pycharm-*',
                          desktop_filename='jetbrains-pycharm.desktop',
-                         packages_requirements=['openjdk-7-jdk', 'jayatana'],
+                         packages_requirements=['openjdk-latest', 'jayatana'],
                          icon_filename='pycharm.png')
 
 
@@ -347,7 +347,7 @@ class Idea(BaseJetBrains):
                          category=category, only_on_archs=['i386', 'amd64'],
                          dir_to_decompress_in_tarball='idea-IC-*',
                          desktop_filename='jetbrains-idea.desktop',
-                         packages_requirements=['openjdk-7-jdk', 'jayatana'],
+                         packages_requirements=['openjdk-latest', 'jayatana'],
                          icon_filename='idea.png')
 
 
@@ -362,7 +362,7 @@ class IdeaUltimate(BaseJetBrains):
                          category=category, only_on_archs=['i386', 'amd64'],
                          dir_to_decompress_in_tarball='idea-IU-*',
                          desktop_filename='jetbrains-idea.desktop',
-                         packages_requirements=['openjdk-7-jdk', 'jayatana'],
+                         packages_requirements=['openjdk-latest', 'jayatana'],
                          icon_filename='idea.png')
 
 
@@ -378,7 +378,7 @@ class RubyMine(BaseJetBrains):
                          only_on_archs=['i386', 'amd64'],
                          dir_to_decompress_in_tarball='RubyMine-*',
                          desktop_filename='jetbrains-rubymine.desktop',
-                         packages_requirements=['openjdk-7-jdk', 'jayatana'],
+                         packages_requirements=['openjdk-latest', 'jayatana'],
                          icon_filename='rubymine.png')
 
 
@@ -394,7 +394,7 @@ class WebStorm(BaseJetBrains):
                          only_on_archs=['i386', 'amd64'],
                          dir_to_decompress_in_tarball='WebStorm-*',
                          desktop_filename='jetbrains-webstorm.desktop',
-                         packages_requirements=['openjdk-7-jdk', 'jayatana'],
+                         packages_requirements=['openjdk-latest', 'jayatana'],
                          icon_filename='webstorm.svg')
 
 
@@ -410,7 +410,7 @@ class PhpStorm(BaseJetBrains):
                          only_on_archs=['i386', 'amd64'],
                          dir_to_decompress_in_tarball='PhpStorm-*',
                          desktop_filename='jetbrains-phpstorm.desktop',
-                         packages_requirements=['openjdk-7-jdk', 'jayatana'],
+                         packages_requirements=['openjdk-latest', 'jayatana'],
                          icon_filename='webide.png')
 
 
@@ -426,7 +426,7 @@ class CLion(BaseJetBrains):
                          only_on_archs=['amd64'],
                          dir_to_decompress_in_tarball='clion-*',
                          desktop_filename='jetbrains-clion.desktop',
-                         packages_requirements=['openjdk-7-jdk', 'jayatana'],
+                         packages_requirements=['openjdk-latest', 'jayatana'],
                          icon_filename='clion.svg')
 
 
@@ -442,7 +442,7 @@ class DataGrip(BaseJetBrains):
                          only_on_archs=['i386', 'amd64'],
                          dir_to_decompress_in_tarball='DataGrip-*',
                          desktop_filename='jetbrains-datagrip.desktop',
-                         packages_requirements=['openjdk-7-jdk', 'jayatana'],
+                         packages_requirements=['openjdk-latest', 'jayatana'],
                          icon_filename='product.png')
 
 
@@ -469,7 +469,7 @@ class Arduino(umake.frameworks.baseinstaller.BaseInstaller):
                          download_page='http://www.arduino.cc/en/Main/Software',
                          dir_to_decompress_in_tarball='arduino-*',
                          desktop_filename='arduino.desktop',
-                         packages_requirements=['openjdk-7-jdk', 'jayatana', 'gcc-avr', 'avr-libc'],
+                         packages_requirements=['openjdk-latest', 'jayatana', 'gcc-avr', 'avr-libc'],
                          need_root_access=not self.was_in_arduino_group,
                          required_files_path=["arduino"])
         self.scraped_checksum_url = None
@@ -598,7 +598,7 @@ class BaseNetBeans(umake.frameworks.baseinstaller.BaseInstaller):
                          download_page="https://netbeans.org/downloads/zip.html",
                          dir_to_decompress_in_tarball="netbeans*",
                          desktop_filename="netbeans{}.desktop".format(flavour),
-                         packages_requirements=['openjdk-7-jdk', 'jayatana'],
+                         packages_requirements=['openjdk-latest', 'jayatana'],
                          required_files_path=[os.path.join("bin", "netbeans")])
 
     @MainLoop.in_mainloop_thread
@@ -816,7 +816,7 @@ class SpringToolsSuite(umake.frameworks.baseinstaller.BaseInstaller):
                          dir_to_decompress_in_tarball='sts-bundle/sts-*',
                          desktop_filename='STS.desktop',
                          category=category, only_on_archs=['i386', 'amd64'],
-                         packages_requirements=['openjdk-7-jdk'],
+                         packages_requirements=['openjdk-latest'],
                          icon_filename='icon.xpm',
                          required_files_path=["STS"])
         self.arch = '' if platform.machine() == 'i686' else '-x86_64'

--- a/umake/network/requirements_handler.py
+++ b/umake/network/requirements_handler.py
@@ -47,12 +47,24 @@ class RequirementsHandler(object, metaclass=Singleton):
         self.cache = apt.Cache()
         self.executor = futures.ThreadPoolExecutor(max_workers=1)
 
+    def get_latest_jdk(self, bucket):
+        """Check that we install the latest openjdk version available.
+        If we want to use this we include openjdk-latest in the requirements."""
+        java_versions = [8, 7]
+        for value in java_versions:
+            if "openjdk-{}-jdk".format(value) in self.cache:
+                bucket.remove("openjdk-latest")
+                bucket.append("openjdk-{}-jdk".format(value))
+                break
+
     def is_bucket_installed(self, bucket):
         """Check if the bucket is installed
 
         The bucket is a list of packages to check if installed."""
         logger.debug("Check if {} is installed".format(bucket))
         is_installed = True
+        if "openjdk-latest" in bucket:
+            self.get_latest_jdk(bucket)
         for pkg_name in bucket:
             # /!\ danger: if current arch == ':appended_arch', on a non multiarch system, dpkg doesn't
             # understand that. strip :arch then


### PR DESCRIPTION
Added a check in requirements_handler to grab the latest openjdk.

Added a check in the RequirementsHandler, where the requirements are verified.
If in a framework we put openjdk-latest we check:
  if in apt.cache we have openjdk-8 install that
  if not, check for openjdk-7.
To maintain this we just need to add new versions of openjdk when they get released in ubuntu.

The ideal thing would be to add a condition to avoid a particular version, say for example if eclipse wasn't working with openjdk-9.

Alternatively, we could keep default-jdk, and say that if another "java" is installed, it should skip it.
So if nothing is installed, umake would install the default (openjdk-7 at the moment). This could be done in the same place as my commit. (if "javac" exists as a command, remove "default-jdk" from the bucket)

Any ideas?