### PR TITLE
Logic OR in dependency list

### DIFF
--- a/tests/small/test_requirements_handler.py
+++ b/tests/small/test_requirements_handler.py
@@ -496,7 +496,7 @@ class TestRequirementsHandler(DpkgAptSetup):
                     os.path.join(self.dpkg_dir, "status"))
         self.handler.cache.open()
         self.assertTrue(self.handler.is_bucket_installed(test_bucket))
-        self.assertTrue(test_bucket == ['testpackage'])
+        self.assertEqual(test_bucket, ['testpackage'])
 
     def test_or_option_second_installed(self):
         test_bucket = ["testpackage0 | testpackage | testpackage1", "testpackage2"]
@@ -504,7 +504,7 @@ class TestRequirementsHandler(DpkgAptSetup):
                     os.path.join(self.dpkg_dir, "status"))
         self.handler.cache.open()
         self.assertTrue(self.handler.is_bucket_installed(test_bucket))
-        self.assertTrue(test_bucket == ['testpackage2', 'testpackage'])
+        self.assertEqual(test_bucket, ['testpackage2', 'testpackage'])
 
     def test_or_option_third_installed(self):
         test_bucket = ["testpackage0 | testpackage1 | testpackage", "testpackage2"]
@@ -512,19 +512,19 @@ class TestRequirementsHandler(DpkgAptSetup):
                     os.path.join(self.dpkg_dir, "status"))
         self.handler.cache.open()
         self.assertTrue(self.handler.is_bucket_installed(test_bucket))
-        self.assertTrue(test_bucket == ['testpackage2', 'testpackage'])
+        self.assertEqual(test_bucket, ['testpackage2', 'testpackage'])
 
     def test_or_option_is_first_available(self):
         test_bucket = ["testpackage | testpackage42", "testpackage1"]
         self.handler.cache.open()
         self.assertTrue(self.handler.is_bucket_available(test_bucket))
-        self.assertTrue(test_bucket == ['testpackage1', 'testpackage'])
+        self.assertEqual(test_bucket, ['testpackage1', 'testpackage'])
 
     def test_or_option_is_second_available(self):
         test_bucket = ["testpackage42 | testpackage"]
         self.handler.cache.open()
         self.assertTrue(self.handler.is_bucket_available(test_bucket))
-        self.assertTrue(test_bucket == ['testpackage'])
+        self.assertEqual(test_bucket, ['testpackage'])
 
     def test_or_option_is_none_available(self):
         self.assertFalse(self.handler.is_bucket_available(['testpackage42 | testpackage404']))
@@ -533,4 +533,4 @@ class TestRequirementsHandler(DpkgAptSetup):
         test_bucket = ['testpackage | testpackage0', 'testpackage1']
         self.handler.cache.open()
         self.assertTrue(self.handler.is_bucket_available(test_bucket))
-        self.assertTrue(test_bucket == ['testpackage1', 'testpackage'])
+        self.assertEqual(test_bucket, ['testpackage1', 'testpackage'])

--- a/tests/small/test_requirements_handler.py
+++ b/tests/small/test_requirements_handler.py
@@ -491,22 +491,46 @@ class TestRequirementsHandler(DpkgAptSetup):
         self.assertFalse(self.handler.is_bucket_installed(["testpackage | testpackage0"]))
 
     def test_or_option_first_installed(self):
+        test_bucket = ["testpackage | testpackage1 | testpackage0"]
         shutil.copy(os.path.join(self.apt_status_dir, "testpackage_installed_dpkg_status"),
                     os.path.join(self.dpkg_dir, "status"))
         self.handler.cache.open()
-        self.assertTrue(self.handler.is_bucket_installed(["testpackage | testpackage0"]))
+        self.assertTrue(self.handler.is_bucket_installed(test_bucket))
+        self.assertTrue(test_bucket == ['testpackage'])
 
     def test_or_option_second_installed(self):
+        test_bucket = ["testpackage0 | testpackage | testpackage1", "testpackage2"]
         shutil.copy(os.path.join(self.apt_status_dir, "testpackage_installed_dpkg_status"),
                     os.path.join(self.dpkg_dir, "status"))
         self.handler.cache.open()
-        self.assertTrue(self.handler.is_bucket_installed(["testpackage0 | testpackage"]))
+        self.assertTrue(self.handler.is_bucket_installed(test_bucket))
+        self.assertTrue(test_bucket == ['testpackage2', 'testpackage'])
+
+    def test_or_option_third_installed(self):
+        test_bucket = ["testpackage0 | testpackage1 | testpackage", "testpackage2"]
+        shutil.copy(os.path.join(self.apt_status_dir, "testpackage_installed_dpkg_status"),
+                    os.path.join(self.dpkg_dir, "status"))
+        self.handler.cache.open()
+        self.assertTrue(self.handler.is_bucket_installed(test_bucket))
+        self.assertTrue(test_bucket == ['testpackage2', 'testpackage'])
 
     def test_or_option_is_first_available(self):
-        self.assertTrue(self.handler.is_bucket_available(['testpackage | testpackage42']))
+        test_bucket = ["testpackage | testpackage42", "testpackage1"]
+        self.handler.cache.open()
+        self.assertTrue(self.handler.is_bucket_available(test_bucket))
+        self.assertTrue(test_bucket == ['testpackage1', 'testpackage'])
 
     def test_or_option_is_second_available(self):
-        self.assertTrue(self.handler.is_bucket_available(['testpackage42 | testpackage']))
+        test_bucket = ["testpackage42 | testpackage"]
+        self.handler.cache.open()
+        self.assertTrue(self.handler.is_bucket_available(test_bucket))
+        self.assertTrue(test_bucket == ['testpackage'])
 
     def test_or_option_is_none_available(self):
         self.assertFalse(self.handler.is_bucket_available(['testpackage42 | testpackage404']))
+
+    def test_or_option_both_available(self):
+        test_bucket = ['testpackage | testpackage0', 'testpackage1']
+        self.handler.cache.open()
+        self.assertTrue(self.handler.is_bucket_available(test_bucket))
+        self.assertTrue(test_bucket == ['testpackage1', 'testpackage'])

--- a/tests/small/test_requirements_handler.py
+++ b/tests/small/test_requirements_handler.py
@@ -486,3 +486,27 @@ class TestRequirementsHandler(DpkgAptSetup):
         self.assertIsNotNone(self.done_callback.call_args[0][0].error)
         self.assertFalse(self.handler.is_bucket_installed(["testpackage"]))
         self.expect_warn_error = True
+
+    def test_or_option_none_installed(self):
+        self.assertFalse(self.handler.is_bucket_installed(["testpackage | testpackage0"]))
+
+    def test_or_option_first_installed(self):
+        shutil.copy(os.path.join(self.apt_status_dir, "testpackage_installed_dpkg_status"),
+                    os.path.join(self.dpkg_dir, "status"))
+        self.handler.cache.open()
+        self.assertTrue(self.handler.is_bucket_installed(["testpackage | testpackage0"]))
+
+    def test_or_option_second_installed(self):
+        shutil.copy(os.path.join(self.apt_status_dir, "testpackage_installed_dpkg_status"),
+                    os.path.join(self.dpkg_dir, "status"))
+        self.handler.cache.open()
+        self.assertTrue(self.handler.is_bucket_installed(["testpackage0 | testpackage"]))
+
+    def test_or_option_is_first_available(self):
+        self.assertTrue(self.handler.is_bucket_available(['testpackage | testpackage42']))
+
+    def test_or_option_is_second_available(self):
+        self.assertTrue(self.handler.is_bucket_available(['testpackage42 | testpackage']))
+
+    def test_or_option_is_none_available(self):
+        self.assertFalse(self.handler.is_bucket_available(['testpackage42 | testpackage404']))

--- a/umake/network/requirements_handler.py
+++ b/umake/network/requirements_handler.py
@@ -54,6 +54,13 @@ class RequirementsHandler(object, metaclass=Singleton):
         logger.debug("Check if {} is installed".format(bucket))
         is_installed = True
         for pkg_name in bucket:
+            if ' | ' in pkg_name:
+                for package in pkg_name.split(' | '):
+                    if self.is_bucket_installed([package]):
+                        bucket.remove(pkg_name)
+                        bucket.append(package)
+                        pkg_name = package
+                        break
             # /!\ danger: if current arch == ':appended_arch', on a non multiarch system, dpkg doesn't
             # understand that. strip :arch then
             if ":" in pkg_name:
@@ -69,6 +76,13 @@ class RequirementsHandler(object, metaclass=Singleton):
         """Check if bucket available on the platform"""
         all_in_cache = True
         for pkg_name in bucket:
+            if ' | ' in pkg_name:
+                for package in pkg_name.split(' | '):
+                    if self.is_bucket_available([package]):
+                        bucket.remove(pkg_name)
+                        bucket.append(package)
+                        pkg_name = package
+                        break
             if pkg_name not in self.cache:
                 # this can be also a foo:arch and we don't have <arch> added. Tell is may be available
                 if ":" in pkg_name:


### PR DESCRIPTION
Add the possilibity to specify a dependency on one of n packages.
At least one of them has to be installed for the dependency to be met

Example. The Eclipse versions could depend on openjdk-8-jdk or openjdk-7-jdk (or even oracle-jdk).
All we need to do is specify an order.
The dependency on packages `"A | B | C"` would: ("|" being the or)

- check if one of them is installed
- if not install the first available.