### PR TITLE
Unity3D on lts mesa updates

### DIFF
--- a/umake/frameworks/games.py
+++ b/umake/frameworks/games.py
@@ -121,14 +121,15 @@ class Unity3D(umake.frameworks.baseinstaller.BaseInstaller):
                          need_root_access=True,
                          # Note that some packages requirements essential to the system itself are not listed (we
                          # don't want to create fake packages and kill the container for medium tests)
-                         packages_requirements=["gconf-service", "lib32gcc1", "lib32stdc++6", "libasound2", "libcairo2",
-                                                "libcap2", "libcups2", "libfontconfig1", "libfreetype6", "libgconf-2-4",
-                                                "libgdk-pixbuf2.0-0", "libglu1-mesa", "libgtk2.0-0",
-                                                "libgl1-mesa-glx | libgl1-mesa-glx-lts-vivid | libgl1-mesa-glx-lts-wily",
-                                                "libnspr4", "libnss3", "libpango1.0-0", "libpq5", "libxcomposite1",
-                                                "libxcursor1", "libxdamage1", "libxext6", "libxfixes3", "libxi6",
-                                                "libxrandr2", "libxrender1", "libxtst6",
-                                                "monodevelop"])  # monodevelop is for mono deps, temporary
+                         packages_requirements=[
+                             "gconf-service", "lib32gcc1", "lib32stdc++6", "libasound2", "libcairo2",
+                             "libcap2", "libcups2", "libfontconfig1", "libfreetype6", "libgconf-2-4",
+                             "libgdk-pixbuf2.0-0", "libglu1-mesa", "libgtk2.0-0",
+                             "libgl1-mesa-glx | libgl1-mesa-glx-lts-vivid | libgl1-mesa-glx-lts-wily",
+                             "libnspr4", "libnss3", "libpango1.0-0", "libpq5", "libxcomposite1",
+                             "libxcursor1", "libxdamage1", "libxext6", "libxfixes3", "libxi6",
+                             "libxrandr2", "libxrender1", "libxtst6",
+                             "monodevelop"])  # monodevelop is for mono deps, temporary
 
     def parse_download_link(self, line, in_download):
         """Parse Unity3d download links"""

--- a/umake/frameworks/games.py
+++ b/umake/frameworks/games.py
@@ -123,7 +123,8 @@ class Unity3D(umake.frameworks.baseinstaller.BaseInstaller):
                          # don't want to create fake packages and kill the container for medium tests)
                          packages_requirements=["gconf-service", "lib32gcc1", "lib32stdc++6", "libasound2", "libcairo2",
                                                 "libcap2", "libcups2", "libfontconfig1", "libfreetype6", "libgconf-2-4",
-                                                "libgdk-pixbuf2.0-0", "libgl1-mesa-glx", "libglu1-mesa", "libgtk2.0-0",
+                                                "libgdk-pixbuf2.0-0", "libglu1-mesa", "libgtk2.0-0",
+                                                "libgl1-mesa-glx | libgl1-mesa-glx-lts-vivid | libgl1-mesa-glx-lts-wily",
                                                 "libnspr4", "libnss3", "libpango1.0-0", "libpq5", "libxcomposite1",
                                                 "libxcursor1", "libxdamage1", "libxext6", "libxfixes3", "libxi6",
                                                 "libxrandr2", "libxrender1", "libxtst6",

--- a/umake/frameworks/games.py
+++ b/umake/frameworks/games.py
@@ -125,8 +125,8 @@ class Unity3D(umake.frameworks.baseinstaller.BaseInstaller):
                              "gconf-service", "lib32gcc1", "lib32stdc++6", "libasound2", "libcairo2",
                              "libcap2", "libcups2", "libfontconfig1", "libfreetype6", "libgconf-2-4",
                              "libgdk-pixbuf2.0-0", "libglu1-mesa", "libgtk2.0-0",
-                             "libgl1-mesa-glx-lts-wily |  | libgl1-mesa-glx-lts-vivid |\
-                             libgl1-mesa-glx-lts-utopic, libgl1-mesa-glx",
+                             "libgl1-mesa-glx-lts-wily | libgl1-mesa-glx-lts-vivid |\
+                             libgl1-mesa-glx-lts-utopic | libgl1-mesa-glx",
                              "libnspr4", "libnss3", "libpango1.0-0", "libpq5", "libxcomposite1",
                              "libxcursor1", "libxdamage1", "libxext6", "libxfixes3", "libxi6",
                              "libxrandr2", "libxrender1", "libxtst6",

--- a/umake/frameworks/games.py
+++ b/umake/frameworks/games.py
@@ -124,9 +124,9 @@ class Unity3D(umake.frameworks.baseinstaller.BaseInstaller):
                          packages_requirements=[
                              "gconf-service", "lib32gcc1", "lib32stdc++6", "libasound2", "libcairo2",
                              "libcap2", "libcups2", "libfontconfig1", "libfreetype6", "libgconf-2-4",
-                             "libgdk-pixbuf2.0-0", "libgtk2.0-0",
-                             "libglu1-mesa | libglu1-mesa-lts-vivid | libglu1-mesa-lts-wily",
-                             "libgl1-mesa-glx | libgl1-mesa-glx-lts-vivid | libgl1-mesa-glx-lts-wily",
+                             "libgdk-pixbuf2.0-0", "libglu1-mesa", "libgtk2.0-0",
+                             "libgl1-mesa-glx | libgl1-mesa-glx-lts-vivid |\
+                             libgl1-mesa-glx-lts-utopic, libgl1-mesa-glx-lts-wily",
                              "libnspr4", "libnss3", "libpango1.0-0", "libpq5", "libxcomposite1",
                              "libxcursor1", "libxdamage1", "libxext6", "libxfixes3", "libxi6",
                              "libxrandr2", "libxrender1", "libxtst6",

--- a/umake/frameworks/games.py
+++ b/umake/frameworks/games.py
@@ -125,8 +125,8 @@ class Unity3D(umake.frameworks.baseinstaller.BaseInstaller):
                              "gconf-service", "lib32gcc1", "lib32stdc++6", "libasound2", "libcairo2",
                              "libcap2", "libcups2", "libfontconfig1", "libfreetype6", "libgconf-2-4",
                              "libgdk-pixbuf2.0-0", "libglu1-mesa", "libgtk2.0-0",
-                             "libgl1-mesa-glx-lts-wily | libgl1-mesa-glx-lts-vivid |\
-                             libgl1-mesa-glx-lts-utopic | libgl1-mesa-glx",
+                             "libgl1-mesa-glx | libgl1-mesa-glx-lts-utopic |\
+                              libgl1-mesa-glx-lts-vivid | libgl1-mesa-glx-lts-wily",
                              "libnspr4", "libnss3", "libpango1.0-0", "libpq5", "libxcomposite1",
                              "libxcursor1", "libxdamage1", "libxext6", "libxfixes3", "libxi6",
                              "libxrandr2", "libxrender1", "libxtst6",

--- a/umake/frameworks/games.py
+++ b/umake/frameworks/games.py
@@ -124,7 +124,8 @@ class Unity3D(umake.frameworks.baseinstaller.BaseInstaller):
                          packages_requirements=[
                              "gconf-service", "lib32gcc1", "lib32stdc++6", "libasound2", "libcairo2",
                              "libcap2", "libcups2", "libfontconfig1", "libfreetype6", "libgconf-2-4",
-                             "libgdk-pixbuf2.0-0", "libglu1-mesa", "libgtk2.0-0",
+                             "libgdk-pixbuf2.0-0", "libgtk2.0-0",
+                             "libglu1-mesa | libglu1-mesa-lts-vivid | libglu1-mesa-lts-wily",
                              "libgl1-mesa-glx | libgl1-mesa-glx-lts-vivid | libgl1-mesa-glx-lts-wily",
                              "libnspr4", "libnss3", "libpango1.0-0", "libpq5", "libxcomposite1",
                              "libxcursor1", "libxdamage1", "libxext6", "libxfixes3", "libxi6",

--- a/umake/frameworks/games.py
+++ b/umake/frameworks/games.py
@@ -125,8 +125,8 @@ class Unity3D(umake.frameworks.baseinstaller.BaseInstaller):
                              "gconf-service", "lib32gcc1", "lib32stdc++6", "libasound2", "libcairo2",
                              "libcap2", "libcups2", "libfontconfig1", "libfreetype6", "libgconf-2-4",
                              "libgdk-pixbuf2.0-0", "libglu1-mesa", "libgtk2.0-0",
-                             "libgl1-mesa-glx | libgl1-mesa-glx-lts-vivid |\
-                             libgl1-mesa-glx-lts-utopic, libgl1-mesa-glx-lts-wily",
+                             "libgl1-mesa-glx-lts-wily |  | libgl1-mesa-glx-lts-vivid |\
+                             libgl1-mesa-glx-lts-utopic, libgl1-mesa-glx",
                              "libnspr4", "libnss3", "libpango1.0-0", "libpq5", "libxcomposite1",
                              "libxcursor1", "libxdamage1", "libxext6", "libxfixes3", "libxi6",
                              "libxrandr2", "libxrender1", "libxtst6",


### PR DESCRIPTION
Added as possible dependencies mesa-lts
Closes: #253 

I'm not running ubuntu 14.04. If somebody could test this to see if we need to change other dependencies it would be good.

On ubuntu non lts it should stop at the first version (non lts); on 14.04 it should stop at the first available one. A problem could arise if there is no version installed. Is that possible?