### PR TITLE
Timeout on download

### DIFF
--- a/tests/small/test_download_center.py
+++ b/tests/small/test_download_center.py
@@ -493,6 +493,14 @@ class TestDownloadCenter(LoggedTestCase):
         self.assertIsNone(result.fd)
         self.expect_warn_error = True
 
+    def test_download_timeout(self):
+        """we fail a download with timeout"""
+        filename = "simplefile"
+        url = self.build_server_address(filename + '-timeout')
+        request = DownloadItem(url, None)
+        DownloadCenter([request], self.callback)
+        self.assertIsNone(self.callback.call_args)
+
 
 class TestDownloadCenterSecure(LoggedTestCase):
     """This will test the download center in secure mode by sending one or more download requests"""

--- a/tests/small/test_download_center.py
+++ b/tests/small/test_download_center.py
@@ -495,12 +495,11 @@ class TestDownloadCenter(LoggedTestCase):
 
     def test_download_timeout(self):
         """we fail a download with timeout"""
-        filename = "simplefile"
-        url = self.build_server_address(filename + '-timeout')
-        request = DownloadItem(url, None)
-        DownloadCenter([request], self.callback)
-        self.assertIsNone(self.callback.call_args)
 
+        filename = "simplefile-timeout"
+        request = self.build_server_address(filename)
+        DownloadCenter([DownloadItem(request, None)], self.callback)
+        self.assertIsNone(self.callback.call_args)
 
 class TestDownloadCenterSecure(LoggedTestCase):
     """This will test the download center in secure mode by sending one or more download requests"""

--- a/tests/tools/local_server.py
+++ b/tests/tools/local_server.py
@@ -29,6 +29,7 @@ import ssl
 from . import get_data_dir
 import urllib
 import urllib.parse
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -196,6 +197,11 @@ class RequestHandler(SimpleHTTPRequestHandler):
                     self.send_error(404)
             # Now we need to chop off the '-headers' part.
             self.path = url.path[:-len('-headers')]
+            super().do_GET()
+        elif 'timeout' in self.path:
+            url = urllib.parse.urlparse(self.path)
+            self.path = url.path[:-len('-timeout')]
+            time.sleep(12)
             super().do_GET()
         else:
             # keep special ?file= to redirect the query

--- a/umake/network/download_center.py
+++ b/umake/network/download_center.py
@@ -32,6 +32,7 @@ import requests
 import requests.exceptions
 from umake.network.ftp_adapter import FTPAdapter
 from umake.tools import ChecksumType, root_lock
+from umake.ui import UI
 
 logger = logging.getLogger(__name__)
 
@@ -146,6 +147,9 @@ class DownloadCenter:
         except requests.exceptions.InvalidSchema as exc:
             # Wrap this for a nicer error message.
             raise BaseException("Protocol not supported.") from exc
+        except requests.exceptions.Timeout as exc:
+            # Wrap this for a nicer error message.
+            raise BaseException("Timeout has occurred.") from exc
 
         if checksum and checksum.checksum_value:
             checksum_type = checksum.checksum_type

--- a/umake/network/download_center.py
+++ b/umake/network/download_center.py
@@ -129,7 +129,8 @@ class DownloadCenter:
         session = requests.Session()
         session.mount('ftp://', FTPAdapter())
         try:
-            with closing(session.get(url, stream=True, headers=headers, cookies=cookies)) as r:
+            with closing(session.get(url, stream=True, headers=headers,
+                                     cookies=cookies, timeout=10.0)) as r:
                 r.raise_for_status()
                 content_size = int(r.headers.get('content-length', -1))
 


### PR DESCRIPTION
This is the timeout added to the download.
I had to add it in DownloadItem so it could be changed for the test.
I'm sure there is a better way to achieve this.

The ideal thing would be to change only lines 133, 134, 147, 148 in download_center.py,
and in test_download_center.py force the download to stop immediately.
That would represent better a real scenario.
