### PR TITLE
added openjdk-8-jdk as a dependency to eclipse and jetbrains

### DIFF
--- a/umake/frameworks/ide.py
+++ b/umake/frameworks/ide.py
@@ -183,7 +183,7 @@ class EclipseJava(BaseEclipse):
                          dir_to_decompress_in_tarball='eclipse',
                          desktop_filename='eclipse-java.desktop',
                          category=category, only_on_archs=['i386', 'amd64'],
-                         packages_requirements=['openjdk-7-jdk'],
+                         packages_requirements=['openjdk-7-jdk | openjdk-8.jdk'],
                          icon_filename='java.png')
 
 
@@ -198,7 +198,7 @@ class EclipseJEE(BaseEclipse):
                          dir_to_decompress_in_tarball='eclipse',
                          desktop_filename='eclipse-jee.desktop',
                          category=category, only_on_archs=['i386', 'amd64'],
-                         packages_requirements=["openjdk-7-jdk"],
+                         packages_requirements=['openjdk-7-jdk | openjdk-8.jdk'],
                          icon_filename='javaee.png')
 
 
@@ -213,7 +213,7 @@ class EclipsePHP(BaseEclipse):
                          dir_to_decompress_in_tarball='eclipse',
                          desktop_filename='eclipse-php.desktop',
                          category=category, only_on_archs=['i386', 'amd64'],
-                         packages_requirements=['openjdk-7-jdk'],
+                         packages_requirements=['openjdk-7-jdk | openjdk-8.jdk'],
                          icon_filename='php.png')
 
 
@@ -228,7 +228,7 @@ class EclipseCPP(BaseEclipse):
                          dir_to_decompress_in_tarball='eclipse',
                          desktop_filename='eclipse-cpp.desktop',
                          category=category, only_on_archs=['i386', 'amd64'],
-                         packages_requirements=['openjdk-7-jdk'],
+                         packages_requirements=['openjdk-7-jdk | openjdk-8.jdk'],
                          icon_filename='cdt.png')
 
 
@@ -338,7 +338,7 @@ class PyCharm(BaseJetBrains):
                          category=category, only_on_archs=['i386', 'amd64'],
                          dir_to_decompress_in_tarball='pycharm-community-*',
                          desktop_filename='jetbrains-pycharm.desktop',
-                         packages_requirements=['openjdk-7-jdk'],
+                         packages_requirements=['openjdk-7-jdk | openjdk-8.jdk'],
                          icon_filename='pycharm.png')
 
 
@@ -353,7 +353,7 @@ class PyCharmEducational(BaseJetBrains):
                          category=category, only_on_archs=['i386', 'amd64'],
                          dir_to_decompress_in_tarball='pycharm-edu*',
                          desktop_filename='jetbrains-pycharm.desktop',
-                         packages_requirements=['openjdk-7-jdk'],
+                         packages_requirements=['openjdk-7-jdk | openjdk-8.jdk'],
                          icon_filename='pycharm.png')
 
 
@@ -368,7 +368,7 @@ class PyCharmProfessional(BaseJetBrains):
                          category=category, only_on_archs=['i386', 'amd64'],
                          dir_to_decompress_in_tarball='pycharm-*',
                          desktop_filename='jetbrains-pycharm.desktop',
-                         packages_requirements=['openjdk-7-jdk'],
+                         packages_requirements=['openjdk-7-jdk | openjdk-8.jdk'],
                          icon_filename='pycharm.png')
 
 
@@ -383,7 +383,7 @@ class Idea(BaseJetBrains):
                          category=category, only_on_archs=['i386', 'amd64'],
                          dir_to_decompress_in_tarball='idea-IC-*',
                          desktop_filename='jetbrains-idea.desktop',
-                         packages_requirements=['openjdk-7-jdk'],
+                         packages_requirements=['openjdk-7-jdk | openjdk-8.jdk'],
                          icon_filename='idea.png')
 
 
@@ -398,7 +398,7 @@ class IdeaUltimate(BaseJetBrains):
                          category=category, only_on_archs=['i386', 'amd64'],
                          dir_to_decompress_in_tarball='idea-IU-*',
                          desktop_filename='jetbrains-idea.desktop',
-                         packages_requirements=['openjdk-7-jdk'],
+                         packages_requirements=['openjdk-7-jdk | openjdk-8.jdk'],
                          icon_filename='idea.png')
 
 
@@ -414,7 +414,7 @@ class RubyMine(BaseJetBrains):
                          only_on_archs=['i386', 'amd64'],
                          dir_to_decompress_in_tarball='RubyMine-*',
                          desktop_filename='jetbrains-rubymine.desktop',
-                         packages_requirements=['openjdk-7-jdk'],
+                         packages_requirements=['openjdk-7-jdk | openjdk-8.jdk'],
                          icon_filename='rubymine.png')
 
 
@@ -430,7 +430,7 @@ class WebStorm(BaseJetBrains):
                          only_on_archs=['i386', 'amd64'],
                          dir_to_decompress_in_tarball='WebStorm-*',
                          desktop_filename='jetbrains-webstorm.desktop',
-                         packages_requirements=['openjdk-7-jdk'],
+                         packages_requirements=['openjdk-7-jdk | openjdk-8.jdk'],
                          icon_filename='webstorm.svg')
 
 
@@ -446,7 +446,7 @@ class PhpStorm(BaseJetBrains):
                          only_on_archs=['i386', 'amd64'],
                          dir_to_decompress_in_tarball='PhpStorm-*',
                          desktop_filename='jetbrains-phpstorm.desktop',
-                         packages_requirements=['openjdk-7-jdk'],
+                         packages_requirements=['openjdk-7-jdk | openjdk-8.jdk'],
                          icon_filename='webide.png')
 
 
@@ -462,7 +462,7 @@ class CLion(BaseJetBrains):
                          only_on_archs=['amd64'],
                          dir_to_decompress_in_tarball='clion-*',
                          desktop_filename='jetbrains-clion.desktop',
-                         packages_requirements=['openjdk-7-jdk'],
+                         packages_requirements=['openjdk-7-jdk | openjdk-8.jdk'],
                          icon_filename='clion.svg')
 
 
@@ -803,7 +803,7 @@ class SpringToolsSuite(umake.frameworks.baseinstaller.BaseInstaller):
                          dir_to_decompress_in_tarball='sts-bundle/sts-*',
                          desktop_filename='STS.desktop',
                          category=category, only_on_archs=['i386', 'amd64'],
-                         packages_requirements=['openjdk-7-jdk'],
+                         packages_requirements=['openjdk-7-jdk | openjdk-8.jdk'],
                          icon_filename='icon.xpm',
                          required_files_path=["STS"])
         self.arch = '' if platform.machine() == 'i686' else '-x86_64'


### PR DESCRIPTION
Added openjdk-8 to eclipse and jetbrains ides.
Just want to be sure of a few things:
1. Are we sure that there are no issues with jdk-8? (there shouldn't be)
2. should we reintroduce jayatana?
3. Do the eap versions of jetbrains ides have the custom jdk?