### PR TITLE
Remove openjdk dependency for arduino

### DIFF
--- a/docker/create_packages.sh
+++ b/docker/create_packages.sh
@@ -109,8 +109,6 @@ dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
 # arduino deps
 mkdir -p $repo_root_dir/arduino
 cd $repo_root_dir/arduino
-create_package openjdk-7-jdk
-create_package jayatana
 create_package gcc-avr
 create_package avr-libc
 dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz

--- a/umake/frameworks/ide.py
+++ b/umake/frameworks/ide.py
@@ -500,7 +500,7 @@ class Arduino(umake.frameworks.baseinstaller.BaseInstaller):
                          download_page='http://www.arduino.cc/en/Main/Software',
                          dir_to_decompress_in_tarball='arduino-*',
                          desktop_filename='arduino.desktop',
-                         packages_requirements=['openjdk-7-jdk', 'jayatana', 'gcc-avr', 'avr-libc'],
+                         packages_requirements=['gcc-avr', 'avr-libc'],
                          need_root_access=not self.was_in_arduino_group,
                          required_files_path=["arduino"])
         self.scraped_checksum_url = None


### PR DESCRIPTION
A version of java 8 is bundled in the archive, so it's not needed as a dependency.

This should be the last thing that had dependencies incompatible with xenial