### PR TITLE
Switch icon for RubyMine to SVG

### DIFF
--- a/umake/frameworks/ide.py
+++ b/umake/frameworks/ide.py
@@ -414,7 +414,7 @@ class RubyMine(BaseJetBrains):
                          packages_requirements=['ruby'],
                          dir_to_decompress_in_tarball='RubyMine-*',
                          desktop_filename='jetbrains-rubymine.desktop',
-                         icon_filename='rubymine.png')
+                         icon_filename='RMlogo.svg')
 
 
 class WebStorm(BaseJetBrains):


### PR DESCRIPTION
The PNG icon in use is very low-quality (32x32) and looks bad in the Unity
launcher.  Use the SVG version instead.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ubuntu/ubuntu-make/324)

<!-- Reviewable:end -->
