### PR TITLE
Change eap test to return_and_wait

### DIFF
--- a/tests/large/__init__.py
+++ b/tests/large/__init__.py
@@ -167,7 +167,7 @@ class LargeFrameworkTests(LoggedTestCase):
         """run the expect query and check that there is no warning or error
 
         It doesn't fail on the given timeout if stdout is progressing"""
-        self.return_and_wait_expect(expect_query, timeout, expect_warn)
+        self.return_and_wait_expect(expect_query, timeout)
         self.assert_for_warn(self.child.before, expect_warn)
 
     def wait_and_no_warn(self, expect_warn=False):

--- a/tests/large/test_ide.py
+++ b/tests/large/test_ide.py
@@ -163,8 +163,8 @@ class IdeaIDETests(LargeFrameworkTests):
         self.name += ' EAP'
 
         self.child = spawn_process(self.command(self.command_args))
-        result = self.expect_and_no_warn(["ERROR: No EAP version available.*\[.*\]",
-                                          "Choose installation path: {}".format(self.installed_path)])
+        result = self.return_and_wait_expect(["ERROR: No EAP version available.*\[.*\]",
+                                              "Choose installation path: {}".format(self.installed_path)])
         if result == 1:
             self.child.sendline("")
             self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)


### PR DESCRIPTION
Fix copy-paste error in expect_and_no_warn
There was another error.
I changed the eap tests and they seem to work properly now