### PR TITLE
Properly remove vscode from web framework

### DIFF
--- a/tests/medium/test_web.py
+++ b/tests/medium/test_web.py
@@ -65,17 +65,3 @@ class PhantomJSInContainer(ContainerTests, test_web.PhantomJSTests):
         umake_command = self.command('{} web phantomjs'.format(UMAKE))
         self.bad_download_page_test(umake_command, download_page_file_path)
         self.assertFalse(self.path_exists(self.exec_path))
-
-
-class VisualStudioCodeInContainer(ContainerTests, test_web.VisualStudioCodeTest):
-    """This will test the Visual Studio Code integration inside a container"""
-
-    TIMEOUT_START = 20
-    TIMEOUT_STOP = 10
-
-    def setUp(self):
-        self.hosts = {443: ["code.visualstudio.com"], 80: ["go.microsoft.com"]}
-        self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'vscode')
-        super().setUp()
-        # override with container path
-        self.installed_path = os.path.join(self.install_base_path, "web", "visual-studio-code")

--- a/umake/frameworks/web.py
+++ b/umake/frameworks/web.py
@@ -28,7 +28,6 @@ import os
 import platform
 import re
 import umake.frameworks.baseinstaller
-from umake.frameworks.ide import VisualStudioCode
 from umake.interactions import Choice, TextWithChoices, DisplayMessage
 from umake.network.download_center import DownloadItem
 from umake.ui import UI
@@ -170,12 +169,3 @@ class PhantomJS(umake.frameworks.baseinstaller.BaseInstaller):
         """Add phantomjs necessary env variables"""
         add_env_to_user(self.name, {"PATH": {"value": os.path.join(self.install_path, "bin")}})
         UI.delayed_display(DisplayMessage(self.RELOGIN_REQUIRE_MSG.format(self.name)))
-
-
-class VisualStudioCode(VisualStudioCode):
-
-    def setup(self, *args, **kwargs):
-        '''Print a deprecation warning before calling parent setup()'''
-        logger.warning("Visual Studio Code is now in the ide category, please refer it from this category from now on. "
-                       "This compatibility will be dropped after Ubuntu 16.04 LTS.")
-        super().setup(*args, **kwargs)


### PR DESCRIPTION
> WARNING: Visual Studio Code is now in the ide category, please refer it from this category from now on. This compatibility will be dropped after Ubuntu 16.04 LTS.

Should we completely remove visual-studio-code from the web framework now?