### PR TITLE
Add set exec path logic into the set_installdir_to_clean method

### DIFF
--- a/umake/frameworks/baseinstaller.py
+++ b/umake/frameworks/baseinstaller.py
@@ -168,6 +168,8 @@ class BaseInstaller(umake.frameworks.BaseFramework):
     def set_installdir_to_clean(self):
         logger.debug("Mark non empty new installation path for cleaning.")
         self._paths_to_clean.add(self.install_path)
+        if self.desktop_filename:
+            self.exec_path = os.path.join(self.install_path, self.required_files_path[0])
         self.download_provider_page()
 
     def download_provider_page(self):

--- a/umake/frameworks/baseinstaller.py
+++ b/umake/frameworks/baseinstaller.py
@@ -139,6 +139,10 @@ class BaseInstaller(umake.frameworks.BaseFramework):
         UI.delayed_display(DisplayMessage("Suppression done"))
         UI.return_main_screen()
 
+    def set_exec_path(self):
+        if self.desktop_filename:
+            self.exec_path = os.path.join(self.install_path, self.required_files_path[0])
+
     def confirm_path(self, path_dir=""):
         """Confirm path dir"""
 
@@ -161,15 +165,13 @@ class BaseInstaller(umake.frameworks.BaseFramework):
                                      "there?".format(path_dir), self.set_installdir_to_clean, UI.return_main_screen))
                     return
         self.install_path = path_dir
-        if self.desktop_filename:
-            self.exec_path = os.path.join(self.install_path, self.required_files_path[0])
+        self.set_exec_path()
         self.download_provider_page()
 
     def set_installdir_to_clean(self):
         logger.debug("Mark non empty new installation path for cleaning.")
         self._paths_to_clean.add(self.install_path)
-        if self.desktop_filename:
-            self.exec_path = os.path.join(self.install_path, self.required_files_path[0])
+        self.set_exec_path()
         self.download_provider_page()
 
     def download_provider_page(self):


### PR DESCRIPTION
When I install a package in a not empty dir, umake will throw an AttributeError like this:

```

Installing Visual Studio Code
ERROR: Unhandled exception    #                                                                                                                                                                                   |
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/umake/tools.py", line 158, in wrapper
    function(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/umake/frameworks/baseinstaller.py", line 411, in decompress_and_install_done
    self.post_install()
  File "/usr/lib/python3/dist-packages/umake/frameworks/ide.py", line 722, in post_install
    exec=self.exec_path,
AttributeError: 'VisualStudioCode' object has no attribute 'exec_path'

```

I realized that there is a little bug in the *confirm_path* method of *baseinstaller.py*. If user lets the installer to  clean the previous install path, then *confirm_path* method will call *set_installdir_to_clean* method and return, so the *exec_path* attribue will not be set.

I added the set_exec_path logic to *set_installdir_to_clean* method to resolve this issue. If you have any questions or concerns please do not hesitate to contact me. Thank you.