### PR TITLE
Fix regex parse for sublime-text

### DIFF
--- a/tests/data/server-content/sublimetext.com/3/index.html
+++ b/tests/data/server-content/sublimetext.com/3/index.html
@@ -1,4 +1,3 @@
-
 <!doctype html>
 <html>
 <head>
@@ -15,7 +14,7 @@
 <div class="navbar">
 <a class="barlink" href="/">Home</a>
 <a class="barlink" href="/3">Download</a>
-<a class="barlink" href="https://www.sublimetext.com/buy">Buy</a>
+<a class="barlink" href="https://www.sublimetext.com/buy?v=3">Buy</a>
 <a class="barlink" href="/blog/">Blog</a>
 <a class="barlink" href="https://forum.sublimetext.com/">Forum</a>
 <a class="barlink" href="/support">Support</a>
@@ -36,8 +35,7 @@ else document.documentElement.className += ' arch_32';
 }
 
 html.plat_osx #dl_osx,
-html.plat_linux.arch_64 #dl_linux_64,
-html.plat_linux.arch_32 #dl_linux_32,
+html.plat_linux #dl_linux,
 html.plat_win.arch_64 #dl_win_64,
 html.plat_win.arch_32 #dl_win_32
 {
@@ -51,17 +49,15 @@ html.plat_win.arch_32 #dl_win_32
 
 <h2>Download</h2>
 
-<p>Sublime Text 3 is currently in beta. The latest build is 3103.</p>
+<p>Sublime Text 3 is currently in beta. The latest build is 3126.</p>
 
 <ul id="dl">
-	<li id="dl_osx"><a href="https://download.sublimetext.com/Sublime Text Build 3103.dmg">OS X</a> (10.7 or later is required)</li>
+	<li id="dl_osx"><a href="https://download.sublimetext.com/Sublime Text Build 3126.dmg">OS X</a> (10.7 or later is required)</li>
 
-	<li id="dl_win_32"><a href="https://download.sublimetext.com/Sublime Text Build 3103 Setup.exe">Windows</a> - also available as a <a href="https://download.sublimetext.com/Sublime Text Build 3103.zip">portable version</a></li>
-	<li id="dl_win_64"><a href="https://download.sublimetext.com/Sublime Text Build 3103 x64 Setup.exe">Windows 64 bit</a> - also available as a <a href="https://download.sublimetext.com/Sublime Text Build 3103 x64.zip">portable version</a></li>
+	<li id="dl_win_32"><a href="https://download.sublimetext.com/Sublime Text Build 3126 Setup.exe">Windows</a> - also available as a <a href="https://download.sublimetext.com/Sublime Text Build 3126.zip">portable version</a></li>
+	<li id="dl_win_64"><a href="https://download.sublimetext.com/Sublime Text Build 3126 x64 Setup.exe">Windows 64 bit</a> - also available as a <a href="https://download.sublimetext.com/Sublime Text Build 3126 x64.zip">portable version</a></li>
 
-	<li id="dl_linux_64"><a href="https://download.sublimetext.com/sublime-text_build-3103_amd64.deb">Ubuntu 64 bit</a> - also available as a <a href="https://download.sublimetext.com/sublime_text_3_build_mock_x64.tar.bz2">tarball</a> for other Linux distributions.</li>
-
-	<li id="dl_linux_32"><a href="https://download.sublimetext.com/sublime-text_build-3103_i386.deb">Ubuntu 32 bit</a> - also available as a <a href="https://download.sublimetext.com/sublime_text_3_build_mock_x32.tar.bz2">tarball</a> for other Linux distributions.</li>
+	<li id="dl_linux"><a href="/docs/3/linux_repositories.html">Linux repos</a> - also available as a <a href="https://download.sublimetext.com/sublime_text_3_build_mock_x64.tar.bz2">64 bit</a> or <a href="https://download.sublimetext.com/sublime_text_3_build_mock_x32.tar.bz2">32 bit tarball</a></li>
 </ul>
 
 <p>Sublime Text may be downloaded and evaluated for free, however a license must be <a href="https://www.sublimetext.com/buy">purchased</a> for continued use. There is currently no enforced time limit for the evaluation.</p>
@@ -73,6 +69,101 @@ html.plat_win.arch_32 #dl_win_32
 <p><a href="/2">Sublime Text 2</a> is also still available.</p>
 
 <br>
+
+<h2>Build 3126</h2>
+<div class="release-date">Release Date: 23 September 2016</div>
+<ul>
+    <li>Added Indexing Status to the Help menu to give more information about what the indexer is doing</li>
+    <li>Fixed a compatibility issue with some third party syntax definitions that include <tt>JavaScript.sublime-syntax</tt></li>
+    <li>Reduced the default number of worker processes used for indexing. This can be manually controlled via the <tt>index_workers</tt> setting</li>
+    <li>API: Updated OpenSSL to 1.0.2i</li>
+</ul>
+
+<h2>Build 3124</h2>
+<div class="release-date">Release Date: 22 September 2016</div>
+<div class="forum-link">See also the <a href="https://www.sublimetext.com/blog/articles/sublime-text-3-build-3124">Blog Post</a></div>
+<ul>
+    <li>Settings now open in a new window, with the default and user settings side-by-side</li>
+    <li>Hovering over a symbol will show a popup indicating where it's defined. This is controlled with the show_definitions setting.</li>
+    <li>Build errors are now shown inline at the location where they occurred. This is controlled with the show_errors_inline setting.</li>
+    <li>Added a menu item and command palette entry to install Package Control</li>
+
+    <li>Various syntax highlighting improvements</li>
+    <li>Significant improvements to the Scala syntax definition, with thanks to <a href="https://github.com/djspiewak">djspiewak</a> and <a href="https://github.com/gwenzek">gwenzek</a></li>
+    <li>Significant improvements to the LaTeX syntax definition, with thanks to <a href="https://github.com/randy3k">randy3k</a></li>
+
+    <li>Improved Goto Definition performance when a large number of files are open</li>
+    <li>Minor improvements to file load times</li>
+    <li>Linux and OSX: Improved memory usage</li>
+
+    <li>Fixed Replace not working as expected in conjunction with regex look behinds</li>
+    <li>Fixed build systems being unable to use "file_patterns" with the <tt>exec</tt> command</li>
+    <li>Corrected tab overlap on HiDPI Windows and Linux configurations</li>
+    <li>OSX: Fixed a graphical glitch when switching tabs</li>
+    <li>OSX: Fixed crash when entering a surrogate pair via hex input</li>
+    <li>Linux: Improved rendering performance for some systems</li>
+
+    <li>File encoding of open files is now stored in the session</li>
+    <li>Build Systems may define a cancel command using the "cancel" key</li>
+    <li>Syntax: Added <tt>clear_scopes</tt> directive, to give more control over the generated scopes</li>
+    <li>Color Schemes: Added <tt>popupCss</tt> key, for defining default popup style sheets</li>
+    <li>Color Schemes: Added <tt>phantomCss</tt> key, for defining default phantom style sheets</li>
+
+    <li>minihtml: HiDPI support was added for Windows and Linux</li>
+    <li>minihtml: Windows style line endings and single quoted attributes are now supported</li>
+    <li>minihtml: Child selectors may now be used in style sheets</li>
+    <li>minihtml: The <tt>inherit</tt> CSS value has been implemented</li>
+    <li>minihtml: <tt>font-family</tt> stacks may now be used</li>
+    <li>minihtml: Support for the <tt>line-height</tt> CSS property was added</li>
+    <li>minihtml: Elements may now be relatively positioned</li>
+    <li>minihtml: Inline elements support <tt>padding</tt> and <tt>background-color</tt> set</li>
+    <li>minihtml: CSS variables and the <tt>var()</tt> function are now supported</li>
+    <li>minihtml: Added the CSS color functions <tt>color()</tt> (partial), <tt>rgb()</tt>, <tt>rgba()</tt>, <tt>hsl()</tt> and <tt>hsla()</tt></li>
+    <li>minihtml: Fixed a stack overflow on Windows with too many unclosed tags</li>
+
+    <li>API: Added <tt>Phantom</tt> and <tt>PhantomSet</tt></li>
+    <li>API: Added <tt>ViewEventListener</tt></li>
+    <li>API: Added <tt>View.is_primary()</tt></li>
+    <li>API: Added <tt>EventListener.on_hover(view, point, hover_zone)</tt></li>
+    <li>API: Added functions to get and set visibility of the minimap, status bar, tabs and menu</li>
+    <li>API: Modifications to a selection are now constrained to the valid range</li>
+    <li>API: Updated Python 3.3 to commit 8e3b9bf917a7, and SQLite to 3.14.1</li>
+
+    <li>Packages: Loading packages will no longer abort if a <tt>.sublime-package</tt> is corrupt</li>
+    <li>Packages: Fixed an edge case when loading third party packages from unicode paths on Windows</li>
+</ul>
+
+<h2>Build 3114</h2>
+<div class="release-date">Release Date: 12 May 2016</div>
+<ul>
+    <li>New C++, JavaScript and Rust syntax definitions with improved accuracy and performance</li>
+    <li>Many other syntax highlighting improvements</li>
+    <li>OSX: Improved rendering performance, especially on high resolution screens</li>
+
+    <li>Improved word wrap behavior</li>
+    <li>Improved spell check behavior</li>
+    <li>Improved file indexing behavior with multiple windows open</li>
+
+    <li>Themes may now be switched on the fly without artifacts</li>
+    <li>HTML: Pressing enter when between a tag pair will increase indentation</li>
+
+    <li>Some snippets have have been moved into a sub-directories, so custom overrides and key bindings that reference them will need to be updated</li>
+    <li><tt>show_scope_name</tt> command shows the scope in a popup</li>
+    <li>Package Development: Added 'Syntax Tests - Regex Compatibility' build variant for evaluating syntax definition performance</li>
+    <li>Package Development: Expanded the set of regexes the new regex engine is able to handle</li>
+    <li>Syntax Definitions: Fixed some cases where pop matches with back references weren't working correctly</li>
+
+    <li>Fixed some Unicode handling issues in Goto Anything</li>
+    <li>Fixed a scenario where changes to <tt>.tmPreferences</tt> files weren't being picked up</li>
+    <li>Fixed a 3096 rendering performance regression</li>
+    <li>Fixed a 3096 regression in regular expressions when using <tt>\x{nnnn}</tt> escapes</li>
+    <li>Fixed a crash that could occur with an invalid result_file_regex settings</li>
+
+    <li>API: Added window.status_message</li>
+    <li>API: Changes to how plugins are loaded. This should be transparent, but resolves a number of corner cases</li>
+    <li>API: Updated to Python 3.3.6, and now includes the _ssl module on Linux, plus sqlite3 and bz2 on all platforms</li>
+    <li>API: Updated OpenSSL to 1.0.2h</li>
+</ul>
 
 <h2>Build 3103</h2>
 <div class="release-date">Release Date: 9 February 2016</div>

--- a/umake/frameworks/ide.py
+++ b/umake/frameworks/ide.py
@@ -888,8 +888,8 @@ class SublimeText(umake.frameworks.baseinstaller.BaseInstaller):
     def parse_download_link(self, line, in_download):
         """Parse SublimeText download links"""
         url = None
-        if '{}.tar.bz2'.format(self.arch_trans[get_current_arch()]) in line:
-            p = re.search(r'also available as a <a href="(.*.tar.bz2)"', line)
+        if '.tar.bz2' in line:
+            p = re.search(r'href="([^<]*{}.tar.bz2)"'.format(self.arch_trans[get_current_arch()]), line)
             with suppress(AttributeError):
                 url = p.group(1)
         return ((url, None), in_download)


### PR DESCRIPTION
I tested this with the new webpage in the mock server and the real website.
It should work properly again now.
The issue was that the two urls are now on the same line on the upstream website.
Fixes #452 