### PR TITLE
Fix unity3d url parse

### DIFF
--- a/umake/frameworks/games.py
+++ b/umake/frameworks/games.py
@@ -164,7 +164,9 @@ class Unity3D(umake.frameworks.baseinstaller.BaseInstaller):
         url_found = False
         if "beta.unity" in line:
             in_download = True
-            p = re.search(r'href="(http://beta.unity.*.html)" target', line)
+            p = re.search(
+                r'href="(http://beta.unity.*.html)" target="_blank" class="externalLink">http://beta.unity3d.com',
+                line)
             with suppress(AttributeError):
                 url_found = True
                 self.download_url = p.group(1)


### PR DESCRIPTION
Fix the unity3d url parse.
The latest post in the forum has an issue so the version downloaded isn't the latest (and the checksum doesn't match)

I also changed the dependencies, to add only the dependencies of monodevelop, this way we can avoid having more than one version, and eventually add the desktop launcher for the included one.

EDIT: Moved the dependency change to another PR to this fix can be merged.