### PR TITLE
Fix ZipFileWithPerm compatability with internal 3.6 API

### DIFF
--- a/umake/decompressor.py
+++ b/umake/decompressor.py
@@ -43,6 +43,9 @@ class Decompressor:
     # http://bugs.python.org/issue15795
     class ZipFileWithPerm(zipfile.ZipFile):
         def _extract_member(self, member, targetpath, pwd):
+            if not isinstance(member, zipfile.ZipInfo):
+                member = self.getinfo(member)
+
             targetpath = super()._extract_member(member, targetpath, pwd)
             mode = member.external_attr >> 16 & 0x1FF
             os.chmod(targetpath, mode)


### PR DESCRIPTION
Internal implementation of the _extract_member private API has changed in 3.6. Adapt the override function to be compatible with 3.6 and pre-3.6.

Fixes https://github.com/ubuntu/ubuntu-make/issues/459