### PR TITLE
Added StartupWMClass to Visual Studio Code's .desktop file. Fixes #481

### DIFF
--- a/umake/frameworks/ide.py
+++ b/umake/frameworks/ide.py
@@ -794,7 +794,8 @@ class VisualStudioCode(umake.frameworks.baseinstaller.BaseInstaller):
                                                "code.png"),
                         exec=self.exec_path,
                         comment=_("Visual Studio focused on modern web and cloud"),
-                        categories="Development;IDE;"))
+                        categories="Development;IDE;",
+                        extra="StartupWMClass=Code"))
 
     def install_framework_parser(self, parser):
         this_framework_parser = super().install_framework_parser(parser)


### PR DESCRIPTION
This pull requests adds a StartupVMClass entry to the Visual Studio's .desktop file. This avoids having two icons in the Ubuntu Dock when running Visual Studio Code

This is one of my first pull requests in GitHub. Please forgive me if I am not following the right procedure.