### PR TITLE
Fix environment variables for Android SDK and NDK.

### DIFF
--- a/umake/frameworks/android.py
+++ b/umake/frameworks/android.py
@@ -131,16 +131,14 @@ class AndroidSDK(umake.frameworks.baseinstaller.BaseInstaller):
 
     def post_install(self):
         """Add necessary environment variables"""
-        add_env_to_user(self.name, {"ANDROID_HOME": {"value": self.install_path, "keep": False}})
-
         # add a few fall-back variables that might be used by some tools
-        add_env_to_user(self.name, {"ANDROID_SDK": {"value": "$ANDROID_HOME", "keep": False}})
         # do not set ANDROID_SDK_HOME here as that is the path of the preference folder expected by the Android tools
-
         # add "platform-tools" to PATH to ensure "adb" can be run once the platform tools are installed via
         # the SDK manager
-        add_env_to_user(self.name, {"PATH": {"value": [os.path.join("$ANDROID_HOME", "tools"),
-                                                       os.path.join("$ANDROID_HOME", "platform-tools")]}})
+        add_env_to_user(self.name, {"ANDROID_HOME": {"value": self.install_path, "keep": False},
+                                    "ANDROID_SDK": {"value": self.install_path, "keep": False},
+                                    "PATH": {"value": [os.path.join(self.install_path, "tools"),
+                                                       os.path.join(self.install_path, "platform-tools")]}})
         UI.delayed_display(DisplayMessage(self.RELOGIN_REQUIRE_MSG.format(self.name)))
 
         # print wiki page message
@@ -170,11 +168,10 @@ class AndroidNDK(umake.frameworks.baseinstaller.BaseInstaller):
 
     def post_install(self):
         """Add necessary environment variables"""
-        add_env_to_user(self.name, {"NDK_ROOT": {"value": self.install_path, "keep": False}})
-
         # add a few fall-back variables that might be used by some tools
-        add_env_to_user(self.name, {"ANDROID_NDK": {"value": "$NDK_ROOT", "keep": False}})
-        add_env_to_user(self.name, {"ANDROID_NDK_HOME": {"value": "$NDK_ROOT", "keep": False}})
+        add_env_to_user(self.name, {"NDK_ROOT": {"value": self.install_path, "keep": False},
+                                    "ANDROID_NDK": {"value": self.install_path, "keep": False},
+                                    "ANDROID_NDK_HOME": {"value": self.install_path, "keep": False}})
 
         # print wiki page message
         UI.display(DisplayMessage("NDK installed in {}. More information on how to use it on {}".format(


### PR DESCRIPTION
The add_env_to_user function must be called only once, it takes a dictionary of environment variables as a second parameter.