### PR TITLE
Fix try_exec on android-studio and blender

### DIFF
--- a/umake/frameworks/android.py
+++ b/umake/frameworks/android.py
@@ -101,7 +101,7 @@ class AndroidStudio(umake.frameworks.baseinstaller.BaseInstaller):
         """Create the Android Studio launcher"""
         create_launcher(self.desktop_filename, get_application_desktop_file(name=_("Android Studio"),
                         icon_path=os.path.join(self.install_path, "bin", "studio.png"),
-                        try_exec='"{}" %f'.format(os.path.join(self.install_path, "bin", "studio.sh")),
+                        try_exec=os.path.join(self.install_path, "bin", "studio.sh"),
                         exec=self.exec_link_name,
                         comment=_("Android Studio developer environment"),
                         categories="Development;IDE;",

--- a/umake/frameworks/games.py
+++ b/umake/frameworks/games.py
@@ -157,7 +157,7 @@ class Blender(umake.frameworks.baseinstaller.BaseInstaller):
         """Create the Blender launcher"""
         create_launcher(self.desktop_filename, get_application_desktop_file(name=_("Blender"),
                         icon_path=os.path.join(self.install_path, "icons", "scalable", "apps", "blender.svg"),
-                        try_exec='"{}" %f'.format(self.exec_path),
+                        try_exec=self.exec_path,
                         exec=self.exec_link_name,
                         comment=self.description,
                         categories="Development;IDE;Graphics"))


### PR DESCRIPTION
try_exec should only point to the executable