### PR TITLE
Version update

### DIFF
--- a/tests/data/testframeworks/baseinstallerfake.py
+++ b/tests/data/testframeworks/baseinstallerfake.py
@@ -82,12 +82,18 @@ class BaseFramework(umake.frameworks.baseinstaller.BaseInstaller):
                          checksum_type=ChecksumType.sha1,
                          dir_to_decompress_in_tarball="base-framework-*",
                          desktop_filename="base-framework.desktop",
-                         required_files_path=[os.path.join("bin", "studio.sh")], **kwargs)
+                         required_files_path=[os.path.join("bin", "studio.sh")],
+                         updatable=True, **kwargs)
 
         arch = platform.machine()
         self.tag = 'id="linux-bundle64"'
         if arch == 'i686':
             self.tag = 'id="linux-bundle32"'
+
+    update_parse = ">android-studio-ide-(.*)-linux.zip"
+
+    def get_version(self):
+        return "135.1641136"
 
     def parse_license(self, line, license_txt, in_license):
         """Parse download page for license"""

--- a/tests/large/test_baseinstaller.py
+++ b/tests/large/test_baseinstaller.py
@@ -536,3 +536,38 @@ class BaseInstallerTests(LargeFrameworkTests):
 
             # we have nothing installed
             self.assertFalse(self.launcher_exists_and_is_pinned(self.desktop_filename))
+
+    def test_update_not_available(self):
+        for loop in ("install", "update"):
+            if loop == "update":
+                pass
+                self.child = spawn_process(self.command('{} base base-framework --update'.format(UMAKE)))
+                self.expect_and_no_warn("\[.*\] ")
+                self.child.sendline("a")
+                self.expect_and_no_warn("Framework Base Framework already up to date",
+                                        timeout=self.TIMEOUT_INSTALL_PROGRESS)
+            else:
+                self.child = spawn_process(self.command('{} base base-framework'.format(UMAKE)))
+                self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
+                self.child.sendline("")
+                self.expect_and_no_warn("\[.*\] ")
+                self.child.sendline("a")
+                self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
+                self.wait_and_close()
+
+    def test_update_available(self):
+        self.child = spawn_process(self.command('{} base base-framework'.format(UMAKE)))
+        self.expect_and_no_warn("Choose installation path: {}".format(self.installed_path))
+        self.child.sendline("")
+        self.expect_and_no_warn("\[.*\] ")
+        self.child.sendline("a")
+        self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
+        self.wait_and_close()
+        with swap_file_and_restore(self.download_page_file_path) as content:
+            with open(self.download_page_file_path, "w") as newfile:
+                newfile.write(content.replace('135.1641136-linux.zip', "136.123-linux.zip"))
+            self.child = spawn_process(self.command('{} base base-framework --update'.format(UMAKE)))
+            self.expect_and_no_warn("\[.*\] ")
+            self.child.sendline("a")
+            self.expect_and_no_warn("Installation done", timeout=self.TIMEOUT_INSTALL_PROGRESS)
+            self.wait_and_close()

--- a/tests/small/test_frameworks_loader.py
+++ b/tests/small/test_frameworks_loader.py
@@ -297,12 +297,13 @@ class TestFrameworkLoader(BaseFrameworkLoader):
         args.framework = "framework-b"
         args.accept_license = False
         args.remove = False
+        args.update = False
         with patch.object(self.CategoryHandler.categories[args.category].frameworks["framework-b"], "setup")\
                 as setup_call:
             self.CategoryHandler.categories[args.category].run_for(args)
 
             self.assertTrue(setup_call.called)
-            self.assertEqual(setup_call.call_args, call(install_path=None, auto_accept_license=False))
+            self.assertEqual(setup_call.call_args, call(install_path=None, auto_accept_license=False, update=False))
 
     def test_parse_no_framework_run_default_for_category(self):
         """Parsing category will run default framework"""
@@ -312,11 +313,12 @@ class TestFrameworkLoader(BaseFrameworkLoader):
         args.framework = None
         args.accept_license = False
         args.remove = False
+        args.update = False
         with patch.object(self.CategoryHandler.categories[args.category].frameworks["framework-a"], "setup")\
                 as setup_call:
             self.CategoryHandler.categories[args.category].run_for(args)
             self.assertTrue(setup_call.called)
-            self.assertEqual(setup_call.call_args, call(install_path=None, auto_accept_license=False))
+            self.assertEqual(setup_call.call_args, call(install_path=None, auto_accept_license=False, update=False))
 
     def test_parse_category_and_framework_run_correct_remove_framework(self):
         """Parsing category and framework with --remove run remove on right category and framework"""
@@ -370,7 +372,6 @@ class TestFrameworkLoader(BaseFrameworkLoader):
 
     def test_parse_category_and_framework_cannot_install_not_installable_but_installed_framework(self):
         """We cannot install frameworks that are not installable but already installed (and so, registered)"""
-        self.expect_warn_error = True
         args = Mock()
         args.category = "category-r"
         args.destdir = None
@@ -402,12 +403,13 @@ class TestFrameworkLoader(BaseFrameworkLoader):
         args.framework = "framework-b"
         args.accept_license = True
         args.remove = False
+        args.update = False
         with patch.object(self.CategoryHandler.categories[args.category].frameworks["framework-b"], "setup")\
                 as setup_call:
             self.CategoryHandler.categories[args.category].run_for(args)
 
             self.assertTrue(setup_call.called)
-            self.assertEqual(setup_call.call_args, call(install_path=None, auto_accept_license=True))
+            self.assertEqual(setup_call.call_args, call(install_path=None, auto_accept_license=True, update=False))
 
     def test_uninstantiable_framework(self):
         """A uninstantiable framework isn't loaded"""

--- a/umake/__init__.py
+++ b/umake/__init__.py
@@ -123,6 +123,7 @@ def main():
                                      add_help=False)
     parser.add_argument('--help', action=_HelpAction, help=_('Show this help'))  # add custom help
     parser.add_argument("-v", "--verbose", action="count", default=0, help=_("Increase output verbosity (2 levels)"))
+    parser.add_argument("--update", action="store_true", help=_("Update installed frameworks (that support update)"))
 
     parser.add_argument('-r', '--remove', action="store_true", help=_("Remove specified framework if installed"))
 

--- a/umake/frameworks/__init__.py
+++ b/umake/frameworks/__init__.py
@@ -382,6 +382,7 @@ def list_frameworks():
                             'is_installable': True or False
                             'is_category_default': True or False
                             'only_for_removal': True or False
+                            'updatable': True or False
                         },
                     ]
             },
@@ -398,7 +399,8 @@ def list_frameworks():
                 "is_installed": framework.is_installed,
                 "is_installable": framework.is_installable,
                 "is_category_default": framework.is_category_default,
-                "only_for_removal": framework.only_for_removal
+                "only_for_removal": framework.only_for_removal,
+                "updatable": framework.updatable
             }
 
             frameworks_dict.append(new_fram)

--- a/umake/frameworks/__init__.py
+++ b/umake/frameworks/__init__.py
@@ -139,7 +139,7 @@ class BaseFramework(metaclass=abc.ABCMeta):
 
     def __init__(self, name, description, category, force_loading=False, logo_path=None, is_category_default=False,
                  install_path_dir=None, only_on_archs=None, only_ubuntu_version=None, packages_requirements=None,
-                 only_for_removal=False, expect_license=False, need_root_access=False):
+                 only_for_removal=False, expect_license=False, need_root_access=False, updatable=False):
         self.name = name
         self.description = description
         self.logo_path = None
@@ -151,6 +151,7 @@ class BaseFramework(metaclass=abc.ABCMeta):
         self.packages_requirements.extend(self.category.packages_requirements)
         self.only_for_removal = only_for_removal
         self.expect_license = expect_license
+        self.updatable = updatable
 
         # don't detect anything for completion mode (as we need to be quick), so avoid opening apt cache and detect
         # if it's installed.
@@ -260,6 +261,10 @@ class BaseFramework(metaclass=abc.ABCMeta):
             logger.error(_("You can't remove {} as it isn't installed".format(self.name)))
             UI.return_main_screen(status_code=2)
 
+    def version(self):
+        """Method call to get the verison for the current framework"""
+        pass
+
     def mark_in_config(self):
         """Mark the installation as installed in the config file"""
         config = ConfigHandler().config
@@ -292,6 +297,8 @@ class BaseFramework(metaclass=abc.ABCMeta):
                                            help=_("Remove framework if installed"))
         this_framework_parser.add_argument('--version', action="store_true",
                                            help=_("Print the framework version if installed"))
+        this_framework_parser.add_argument('--update', action="store_true",
+                                           help=_("Update the framework if installed and possible"))
         if self.expect_license:
             this_framework_parser.add_argument('--accept-license', dest="accept_license", action="store_true",
                                                help=_("Accept license without prompting"))
@@ -302,7 +309,7 @@ class BaseFramework(metaclass=abc.ABCMeta):
         logger.debug("Call run_for on {}".format(self.name))
         if args.version:
             if args.destdir:
-                message = "You can't specify a destination dir while removing a framework"
+                message = "You can't specify a destination dir while getting the version of a framework"
                 logger.error(message)
                 UI.return_main_screen(status_code=2)
             self.version()
@@ -319,7 +326,7 @@ class BaseFramework(metaclass=abc.ABCMeta):
                 install_path = os.path.abspath(os.path.expanduser(args.destdir))
             if self.expect_license and args.accept_license:
                 auto_accept_license = True
-            self.setup(install_path=install_path, auto_accept_license=auto_accept_license)
+            self.setup(install_path=install_path, auto_accept_license=auto_accept_license, update=args.update)
 
 
 class MainCategory(BaseCategory):

--- a/umake/frameworks/__init__.py
+++ b/umake/frameworks/__init__.py
@@ -290,6 +290,8 @@ class BaseFramework(metaclass=abc.ABCMeta):
                                                                         "destdir should contain a /"))
         this_framework_parser.add_argument('-r', '--remove', action="store_true",
                                            help=_("Remove framework if installed"))
+        this_framework_parser.add_argument('--version', action="store_true",
+                                           help=_("Print the framework version if installed"))
         if self.expect_license:
             this_framework_parser.add_argument('--accept-license', dest="accept_license", action="store_true",
                                                help=_("Accept license without prompting"))
@@ -298,6 +300,12 @@ class BaseFramework(metaclass=abc.ABCMeta):
     def run_for(self, args):
         """Running commands from args namespace"""
         logger.debug("Call run_for on {}".format(self.name))
+        if args.version:
+            if args.destdir:
+                message = "You can't specify a destination dir while removing a framework"
+                logger.error(message)
+                UI.return_main_screen(status_code=2)
+            self.version()
         if args.remove:
             if args.destdir:
                 message = "You can't specify a destination dir while removing a framework"

--- a/umake/frameworks/baseinstaller.py
+++ b/umake/frameworks/baseinstaller.py
@@ -149,7 +149,7 @@ class BaseInstaller(umake.frameworks.BaseFramework):
             self.arg_install_path = self.install_path
             self.reinstall()
             DownloadCenter([DownloadItem(self.download_page)], self.get_metadata_and_check_license, download=False)
-            UI.display(DisplayMessage("Framework {} updated succesfully".format(self.name)))
+            UI.display(DisplayMessage("Framework {} update started".format(self.name)))
         else:
             logger.debug("No update available")
             UI.display(DisplayMessage("Framework {} already up to date".format(self.name)))

--- a/umake/frameworks/baseinstaller.py
+++ b/umake/frameworks/baseinstaller.py
@@ -115,6 +115,10 @@ class BaseInstaller(umake.frameworks.BaseFramework):
         self.confirm_path(self.arg_install_path)
         remove_framework_envs_from_user(self.name)
 
+    def version(self):
+        UI.display(DisplayMessage(self.get_version()))
+        UI.return_main_screen()
+
     def remove(self):
         """Remove current framework if installed
 

--- a/umake/frameworks/baseinstaller.py
+++ b/umake/frameworks/baseinstaller.py
@@ -222,7 +222,7 @@ class BaseInstaller(umake.frameworks.BaseFramework):
         self.set_exec_path()
         self.download_provider_page()
 
-    def download_provider_page(self):
+    def download_provider_page(self, update=False):
         logger.debug("Download application provider page")
         if self.update:
             logger.debug("Check provider page for update")

--- a/umake/frameworks/baseinstaller.py
+++ b/umake/frameworks/baseinstaller.py
@@ -26,7 +26,9 @@ from io import StringIO
 import logging
 from progressbar import ProgressBar
 import os
+import re
 import shutil
+import subprocess
 import umake.frameworks
 from umake.decompressor import Decompressor
 from umake.interactions import InputText, YesNo, LicenseAgreement, DisplayMessage, UnknownProgress
@@ -65,6 +67,7 @@ class BaseInstaller(umake.frameworks.BaseFramework):
         self.desktop_filename = kwargs.get("desktop_filename", None)
         self.icon_filename = kwargs.get("icon_filename", None)
         self.match_last_link = kwargs.get("match_last_link", False)
+        self.updatable = kwargs.get("updatable", False)
         for extra_arg in ["download_page", "checksum_type", "dir_to_decompress_in_tarball",
                           "desktop_filename", "icon_filename", "required_files_path",
                           "match_last_link"]:
@@ -97,13 +100,21 @@ class BaseInstaller(umake.frameworks.BaseFramework):
         logger.debug("{} is installed".format(self.name))
         return True
 
-    def setup(self, install_path=None, auto_accept_license=False):
+    def setup(self, install_path=None, auto_accept_license=False, update=False):
         self.arg_install_path = install_path
         self.auto_accept_license = auto_accept_license
+        self.update = update
         super().setup()
 
         # first step, check if installed
-        if self.is_installed:
+        if self.update and self.updatable:
+            try:
+                self.set_exec_path()
+                self.download_provider_page()
+            except:
+                UI.display(DisplayMessage("The framework {} is not configured to update manually".format(self.name)))
+                UI.return_main_screen()
+        elif self.is_installed:
             UI.display(YesNo("{} is already installed on your system, do you want to reinstall "
                              "it anyway?".format(self.name), self.reinstall, UI.return_main_screen))
         else:
@@ -116,8 +127,40 @@ class BaseInstaller(umake.frameworks.BaseFramework):
         remove_framework_envs_from_user(self.name)
 
     def version(self):
-        UI.display(DisplayMessage(self.get_version()))
+        super().version()
+        if not self.is_installed:
+            logger.error(_("You can't get the version for {} as it isn't installed".format(self.name)))
+            UI.return_main_screen(status_code=2)
+        try:
+            UI.display(DisplayMessage(self.get_version()))
+        except AttributeError as e:
+            logger.error("Version parse not implememted")
         UI.return_main_screen()
+
+    def get_version(self):
+        return re.search(self.version_parse['regex'],
+                         subprocess.check_output(self.version_parse['command'].split()).decode()).group(1)
+
+    @MainLoop.in_mainloop_thread
+    def run_update(self, result):
+        upstream_version = self.get_upstream_version(result)
+        if upstream_version and self.get_version() != upstream_version:
+            logger.debug("Running update of framework {}".format(self.name))
+            self.arg_install_path = self.install_path
+            self.reinstall()
+            DownloadCenter([DownloadItem(self.download_page)], self.get_metadata_and_check_license, download=False)
+            UI.display(DisplayMessage("Framework {} updated succesfully".format(self.name)))
+        else:
+            logger.debug("No update available")
+            UI.display(DisplayMessage("Framework {} already up to date".format(self.name)))
+            UI.return_main_screen()
+
+    def get_upstream_version(self, result):
+        for line in result[self.download_page].buffer:
+            line_content = line.decode()
+            parsed = re.search(self.update_parse, line_content)
+            if parsed:
+                return parsed.group(1)
 
     def remove(self):
         """Remove current framework if installed
@@ -170,7 +213,8 @@ class BaseInstaller(umake.frameworks.BaseFramework):
                     return
         self.install_path = path_dir
         self.set_exec_path()
-        self.download_provider_page()
+        if not self.update:
+            self.download_provider_page()
 
     def set_installdir_to_clean(self):
         logger.debug("Mark non empty new installation path for cleaning.")
@@ -180,7 +224,11 @@ class BaseInstaller(umake.frameworks.BaseFramework):
 
     def download_provider_page(self):
         logger.debug("Download application provider page")
-        DownloadCenter([DownloadItem(self.download_page)], self.get_metadata_and_check_license, download=False)
+        if self.update:
+            logger.debug("Check provider page for update")
+            DownloadCenter([DownloadItem(self.download_page)], self.run_update, download=False)
+        else:
+            DownloadCenter([DownloadItem(self.download_page)], self.get_metadata_and_check_license, download=False)
 
     def parse_license(self, line, license_txt, in_license):
         """Parse license per line, eventually write to license_txt if it's in the license part.

--- a/umake/frameworks/baseinstaller.py
+++ b/umake/frameworks/baseinstaller.py
@@ -108,6 +108,9 @@ class BaseInstaller(umake.frameworks.BaseFramework):
 
         # first step, check if installed
         if self.update and self.updatable:
+            if not self.is_installed:
+                UI.display(DisplayMessage("The framework {} is not installed".format(self.name)))
+                UI.return_main_screen()                
             try:
                 self.set_exec_path()
                 self.download_provider_page()

--- a/umake/frameworks/go.py
+++ b/umake/frameworks/go.py
@@ -49,7 +49,10 @@ class GoLang(umake.frameworks.baseinstaller.BaseInstaller):
                          checksum_type=ChecksumType.sha256,
                          dir_to_decompress_in_tarball="go",
                          required_files_path=[os.path.join("bin", "go")],
-                         **kwargs)
+                         updatable=True, **kwargs)
+
+    update_parse = "go/go(.*).linux-amd64.tar.gz"
+    version_parse = {'regex': 'go version go(.*) linux/amd64', 'command': 'go version'}
 
     def parse_download_link(self, line, in_download):
         """Parse Go download link, expect to find a sha and a url"""

--- a/umake/frameworks/ide.py
+++ b/umake/frameworks/ide.py
@@ -762,6 +762,9 @@ class Atom(umake.frameworks.baseinstaller.BaseInstaller):
                          packages_requirements=["libgconf-2-4"],
                          checksum_type=ChecksumType.md5, **kwargs)
 
+    def get_version(self):
+        return subprocess.check_output(["atom", "--version"]).strip
+
     @MainLoop.in_mainloop_thread
     def get_metadata_and_check_license(self, result):
         logger.debug("Fetched download page, parsing.")

--- a/umake/frameworks/ide.py
+++ b/umake/frameworks/ide.py
@@ -760,10 +760,14 @@ class Atom(umake.frameworks.baseinstaller.BaseInstaller):
                          required_files_path=["atom", "resources/app/apm/bin/apm"],
                          dir_to_decompress_in_tarball="atom-*",
                          packages_requirements=["libgconf-2-4"],
-                         checksum_type=ChecksumType.md5, **kwargs)
+                         checksum_type=ChecksumType.md5,
+                         updatable=True, **kwargs)
 
-    def get_version(self):
-        return subprocess.check_output(["atom", "--version"]).strip
+    def get_upstream_version(self, result):
+        page = result[self.download_page]
+        return json.loads(page.buffer.read().decode())["name"]
+
+    version_parse = {'regex': 'Atom.*: (.*)\n', 'command': 'atom --version'}
 
     @MainLoop.in_mainloop_thread
     def get_metadata_and_check_license(self, result):
@@ -885,12 +889,16 @@ class SublimeText(umake.frameworks.baseinstaller.BaseInstaller):
                          desktop_filename="sublime-text.desktop",
                          required_files_path=["sublime_text"],
                          dir_to_decompress_in_tarball="sublime_text_*",
+                         updatable=True,
                          **kwargs)
 
     arch_trans = {
         "amd64": "x64",
         "i386": "x32"
     }
+
+    update_parse = "https://download.sublimetext.com/sublime_text_3_build_(.*)_x64.tar.bz2"
+    version_parse = {'regex': 'Sublime Text Build (.*)\n', 'command': 'sublime-text --version'}
 
     def parse_download_link(self, line, in_download):
         """Parse SublimeText download links"""

--- a/umake/frameworks/web.py
+++ b/umake/frameworks/web.py
@@ -27,6 +27,7 @@ import logging
 import os
 import platform
 import re
+import subprocess
 import umake.frameworks.baseinstaller
 from umake.interactions import Choice, TextWithChoices, DisplayMessage
 from umake.network.download_center import DownloadItem
@@ -55,6 +56,8 @@ class FirefoxDev(umake.frameworks.baseinstaller.BaseInstaller):
                          desktop_filename="firefox-developer.desktop",
                          required_files_path=["firefox"], **kwargs)
         self.arg_lang = None
+
+    version_parse = {'regex': 'Mozilla Firefox (.*)\n', 'command': 'firefox-developer --version'}
 
     @MainLoop.in_mainloop_thread
     def language_select_callback(self, url):

--- a/umake/ui/cli/__init__.py
+++ b/umake/ui/cli/__init__.py
@@ -239,7 +239,7 @@ def main(parser):
         print(get_frameworks_list_output(args))
         sys.exit(0)
 
-    if args.version:
+    if args.version and not len(arg_to_parse) > 1:
         print(get_version())
         sys.exit(0)
 

--- a/umake/ui/cli/__init__.py
+++ b/umake/ui/cli/__init__.py
@@ -20,6 +20,7 @@
 """Module for loading the command line interface"""
 
 import argcomplete
+from argparse import Namespace
 from contextlib import suppress
 from gettext import gettext as _
 import logging
@@ -250,14 +251,18 @@ def main(parser):
         for category in sorted(categories, key=lambda cat: cat["category_name"]):
             # Sort the frameworks to prevent a random list at each new program execution
             for framework in sorted(category["frameworks"], key=lambda fram: fram["framework_name"]):
-                if framework['framework_name'] in installed and framework['updatable']:
-                    args = [framework, "update"]
-                    print(framework)
-                    # print(args)
-                    # args = parser.parse_args(args)
-                    # print(args)
-                    # run_command_for_args(args)
-        sys.exit(0)
+                if framework['framework_name'] in installed:
+                    if framework['updatable']:
+                        args = Namespace(category=category['category_name'],
+                                destdir=framework['install_path'],
+                                framework=framework['framework_name'],
+                                update=True, version=False, beta=False,
+                                remove=False)
+                        print("Checking " + framework['framework_name'])
+                        # print(args)
+                        # args = parser.parse_args(args)
+                        run_command_for_args(args)
+        # sys.exit(0)
 
     if args.version and not len(arg_to_parse) > 1:
         print(get_version())


### PR DESCRIPTION
Add --version and --update commands for supported frameworks.
This simply compares the installed version with the upstream available version.

The auto-updating frameworks would not be supported.
As an example, firefox-dev only returns the version.
Atom, Sublime-text and go are updatable

Fixes #74 