### PR TITLE
Cleanup: Remove unused imports

### DIFF
--- a/tests/large/test_baseinstaller.py
+++ b/tests/large/test_baseinstaller.py
@@ -155,8 +155,8 @@ class BaseInstallerTests(LargeFrameworkTests):
             self.assert_exec_exists()
 
             # launch it, send SIGTERM and check that it exits fine
-            proc = subprocess.Popen(self.command_as_list(self.exec_path), stdout=subprocess.DEVNULL,
-                                    stderr=subprocess.DEVNULL)
+            subprocess.Popen(self.command_as_list(self.exec_path), stdout=subprocess.DEVNULL,
+                             stderr=subprocess.DEVNULL)
             self.check_and_kill_process([self.JAVAEXEC, self.installed_path], wait_before=self.TIMEOUT_START)
 
     def test_reinstall_other_path(self):

--- a/tests/large/test_basics_cli.py
+++ b/tests/large/test_basics_cli.py
@@ -23,7 +23,7 @@ from contextlib import suppress
 import os
 import subprocess
 from . import LargeFrameworkTests
-from ..tools import LoggedTestCase, UMAKE, get_root_dir
+from ..tools import UMAKE, get_root_dir
 
 
 class BasicCLI(LargeFrameworkTests):

--- a/tests/large/test_games.py
+++ b/tests/large/test_games.py
@@ -21,6 +21,7 @@
 
 from . import LargeFrameworkTests
 import os
+import platform
 import subprocess
 from ..tools import UMAKE, spawn_process
 

--- a/tests/large/test_games.py
+++ b/tests/large/test_games.py
@@ -21,7 +21,6 @@
 
 from . import LargeFrameworkTests
 import os
-import platform
 import subprocess
 from ..tools import UMAKE, spawn_process
 

--- a/tests/large/test_maven.py
+++ b/tests/large/test_maven.py
@@ -20,9 +20,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 """Tests for the Maven category"""
-import subprocess
 import os
-import tempfile
 from tests.large import LargeFrameworkTests
 from tests.tools import UMAKE, spawn_process
 

--- a/tests/medium/test_baseinstaller.py
+++ b/tests/medium/test_baseinstaller.py
@@ -22,7 +22,6 @@
 from . import ContainerTests
 import os
 import subprocess
-import pexpect
 from ..large import test_baseinstaller
 from ..tools import UMAKE, spawn_process, get_data_dir, swap_file_and_restore
 

--- a/tests/medium/test_electronics.py
+++ b/tests/medium/test_electronics.py
@@ -22,10 +22,9 @@
 
 from . import ContainerTests
 import os
-import pexpect
 
 from ..large import test_electronics
-from ..tools import get_data_dir, swap_file_and_restore, UMAKE, spawn_process
+from ..tools import get_data_dir, UMAKE
 
 
 class ArduinoIDEInContainer(ContainerTests, test_electronics.ArduinoIDETests):

--- a/tests/medium/test_rust.py
+++ b/tests/medium/test_rust.py
@@ -22,10 +22,9 @@
 
 from . import ContainerTests
 import os
-import pexpect
 
 from ..large import test_rust
-from ..tools import get_data_dir, UMAKE, swap_file_and_restore, spawn_process
+from ..tools import get_data_dir, UMAKE
 
 
 class RustInContainer(ContainerTests, test_rust.RustTests):

--- a/tests/small/test_cli.py
+++ b/tests/small/test_cli.py
@@ -21,16 +21,12 @@
 
 import importlib
 from ..tools import LoggedTestCase
-from umake.ui.cli import mangle_args_for_default_framework, get_frameworks_list_output
+from umake.ui.cli import mangle_args_for_default_framework
 import os
 import sys
 from ..tools import get_data_dir, change_xdg_path, patchelem
 import umake
-from unittest.mock import patch, Mock
 from umake import frameworks
-from argparse import Namespace
-import tempfile
-import shutil
 
 
 class TestCLIFromFrameworks(LoggedTestCase):

--- a/tests/small/test_requirements_handler.py
+++ b/tests/small/test_requirements_handler.py
@@ -41,8 +41,8 @@ class TestRequirementsHandler(DpkgAptSetup):
     def count_number_progress_call(self, call_args_list, tag):
         """Count the number of tag in progress call and return it"""
         count = 0
-        for call in call_args_list:
-            if call[0][0]['step'] == tag:
+        for call_item in call_args_list:
+            if call_item[0][0]['step'] == tag:
                 count += 1
         return count
 
@@ -125,8 +125,8 @@ class TestRequirementsHandler(DpkgAptSetup):
                       [{'step': 0, 'pkg_size_download': 1, 'percentage': 0.0},
                        {'step': 0, 'pkg_size_download': 1698, 'percentage': 0.0}])
         callfound = False
-        for call in progress_callback.call_args_list:
-            if call[0][0] == {'step': 1, 'percentage': 0.0}:
+        for call_item in progress_callback.call_args_list:
+            if call_item[0][0] == {'step': 1, 'percentage': 0.0}:
                 callfound = True
                 break
         self.assertTrue(callfound, "We expect to have one install step at 0% call in the list")

--- a/tests/small/test_tools.py
+++ b/tests/small/test_tools.py
@@ -20,12 +20,10 @@
 """Tests the various umake tools"""
 
 from concurrent import futures
-from contextlib import contextmanager, suppress
 from gi.repository import GLib
 import os
 import shutil
 import subprocess
-import stat
 import sys
 import tempfile
 from textwrap import dedent

--- a/umake/__init__.py
+++ b/umake/__init__.py
@@ -25,7 +25,7 @@ import logging
 import logging.config
 import os
 import sys
-from umake.frameworks import BaseCategory, load_frameworks
+from umake.frameworks import load_frameworks
 from umake.tools import MainLoop
 from .ui import cli
 import yaml

--- a/umake/frameworks/android.py
+++ b/umake/frameworks/android.py
@@ -24,7 +24,6 @@ from contextlib import suppress
 from gettext import gettext as _
 import logging
 import os
-import platform
 import re
 import umake.frameworks.baseinstaller
 from umake.interactions import DisplayMessage

--- a/umake/frameworks/crystal.py
+++ b/umake/frameworks/crystal.py
@@ -20,15 +20,13 @@
 
 """Go module"""
 
-from contextlib import suppress
 from gettext import gettext as _
 import json
 import logging
 import os
-import re
 import umake.frameworks.baseinstaller
 from umake.interactions import DisplayMessage
-from umake.tools import get_current_arch, add_env_to_user, ChecksumType, MainLoop
+from umake.tools import get_current_arch, add_env_to_user, MainLoop
 from umake.network.download_center import DownloadItem
 from umake.ui import UI
 

--- a/umake/frameworks/electronics.py
+++ b/umake/frameworks/electronics.py
@@ -20,28 +20,21 @@
 
 
 """Generic Electronics module."""
-from abc import ABCMeta, abstractmethod
 from concurrent import futures
 from contextlib import suppress
 from gettext import gettext as _
 import grp
-from io import StringIO
-import json
 import logging
 import os
 from os.path import join
 import pwd
-import platform
 import re
 import subprocess
-from urllib import parse
-import shutil
 
 import umake.frameworks.baseinstaller
-from umake.interactions import DisplayMessage, LicenseAgreement
+from umake.interactions import DisplayMessage
 from umake.network.download_center import DownloadCenter, DownloadItem
-from umake.tools import as_root, create_launcher, get_application_desktop_file, ChecksumType, Checksum, MainLoop,\
-    strip_tags, add_env_to_user, add_exec_link, get_current_arch
+from umake.tools import as_root, create_launcher, get_application_desktop_file, ChecksumType, Checksum, MainLoop
 from umake.ui import UI
 
 logger = logging.getLogger(__name__)

--- a/umake/frameworks/electronics.py
+++ b/umake/frameworks/electronics.py
@@ -34,7 +34,8 @@ import subprocess
 import umake.frameworks.baseinstaller
 from umake.interactions import DisplayMessage
 from umake.network.download_center import DownloadCenter, DownloadItem
-from umake.tools import as_root, create_launcher, get_application_desktop_file, ChecksumType, Checksum, MainLoop
+from umake.tools import as_root, create_launcher, get_application_desktop_file, ChecksumType, Checksum,\
+    MainLoop, get_current_arch
 from umake.ui import UI
 
 logger = logging.getLogger(__name__)

--- a/umake/frameworks/games.py
+++ b/umake/frameworks/games.py
@@ -20,6 +20,7 @@
 
 """Game IDEs module"""
 
+from concurrent import futures
 from contextlib import suppress
 from gettext import gettext as _
 import logging
@@ -66,7 +67,7 @@ class Stencyl(umake.frameworks.baseinstaller.BaseInstaller):
 
     def parse_download_link(self, line, in_download):
         """Parse Stencyl download links"""
-        url, md5sum = (None, None)
+        url = None
         if ">Linux <" in line:
             in_download = True
         if in_download:

--- a/umake/frameworks/games.py
+++ b/umake/frameworks/games.py
@@ -20,10 +20,8 @@
 
 """Game IDEs module"""
 
-from concurrent import futures
 from contextlib import suppress
 from gettext import gettext as _
-import glob
 import logging
 import os
 import re
@@ -34,7 +32,7 @@ import json
 import umake.frameworks.baseinstaller
 from umake.network.download_center import DownloadItem, DownloadCenter
 from umake.tools import as_root, create_launcher, get_application_desktop_file, get_current_arch,\
-    ChecksumType, MainLoop, Checksum, add_exec_link
+    ChecksumType, MainLoop, Checksum
 from umake.ui import UI
 
 logger = logging.getLogger(__name__)

--- a/umake/frameworks/ide.py
+++ b/umake/frameworks/ide.py
@@ -21,28 +21,21 @@
 
 """Generic IDE module."""
 from abc import ABCMeta, abstractmethod
-from concurrent import futures
 from contextlib import suppress
 from gettext import gettext as _
-import grp
-from io import StringIO
 import json
 import logging
 import os
 from os.path import join
-import pwd
 import platform
 import re
-import subprocess
-from urllib import parse
 import shutil
 
 import umake.frameworks.baseinstaller
 from umake.frameworks.electronics import Arduino
-from umake.interactions import DisplayMessage, LicenseAgreement
 from umake.network.download_center import DownloadCenter, DownloadItem
-from umake.tools import as_root, create_launcher, get_application_desktop_file, ChecksumType, Checksum, MainLoop,\
-    strip_tags, add_env_to_user, add_exec_link, get_current_arch
+from umake.tools import create_launcher, get_application_desktop_file, ChecksumType, Checksum, MainLoop,\
+    add_exec_link, get_current_arch
 from umake.ui import UI
 
 logger = logging.getLogger(__name__)

--- a/umake/frameworks/nodejs.py
+++ b/umake/frameworks/nodejs.py
@@ -20,6 +20,7 @@
 
 """Nodejs module"""
 
+from contextlib import suppress
 from gettext import gettext as _
 import logging
 import os
@@ -68,7 +69,6 @@ class NodejsLang(umake.frameworks.baseinstaller.BaseInstaller):
             logger.error("An error occurred while downloading {}: {}".format(self.download_page, error_msg))
             UI.return_main_screen(status_code=1)
 
-        url = False
         for line in result[self.download_page].buffer:
             line_content = line.decode()
             with suppress(AttributeError):

--- a/umake/frameworks/nodejs.py
+++ b/umake/frameworks/nodejs.py
@@ -20,16 +20,14 @@
 
 """Nodejs module"""
 
-from contextlib import suppress
 from gettext import gettext as _
 import logging
 import os
 import re
-import subprocess
 import umake.frameworks.baseinstaller
 from umake.network.download_center import DownloadCenter, DownloadItem
 from umake.interactions import DisplayMessage
-from umake.tools import get_current_arch, add_env_to_user, ChecksumType, MainLoop
+from umake.tools import get_current_arch, add_env_to_user, ChecksumType
 from umake.ui import UI
 
 logger = logging.getLogger(__name__)

--- a/umake/frameworks/rust.py
+++ b/umake/frameworks/rust.py
@@ -23,15 +23,12 @@
 
 from contextlib import suppress
 from gettext import gettext as _
-from glob import glob
 import logging
 import os
 import re
 import umake.frameworks.baseinstaller
 from umake.interactions import DisplayMessage
-from umake.network.download_center import DownloadItem, DownloadCenter
-from umake.tools import get_current_arch, add_env_to_user, ChecksumType, \
-    MainLoop, Checksum
+from umake.tools import get_current_arch, add_env_to_user
 from umake.ui import UI
 
 logger = logging.getLogger(__name__)

--- a/umake/frameworks/web.py
+++ b/umake/frameworks/web.py
@@ -31,7 +31,7 @@ import umake.frameworks.baseinstaller
 from umake.interactions import Choice, TextWithChoices, DisplayMessage
 from umake.network.download_center import DownloadItem
 from umake.ui import UI
-from umake.tools import create_launcher, get_application_desktop_file, MainLoop, ChecksumType,\
+from umake.tools import create_launcher, get_application_desktop_file, MainLoop,\
     get_current_arch, add_env_to_user
 
 logger = logging.getLogger(__name__)

--- a/umake/ui/__init__.py
+++ b/umake/ui/__init__.py
@@ -20,7 +20,6 @@
 """Abstracted UI interface that will be overriden by different UI types"""
 
 import logging
-from contextlib import suppress
 from gi.repository import GLib
 from umake.tools import Singleton, MainLoop
 from umake.settings import get_version, get_latest_version


### PR DESCRIPTION
Using flake8 --select=F401 I selected and removed only the really unused imports.
Most of them come from copying existing frameworks, or replacing parts