### PR TITLE
Add docker to travis

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,6 @@ coverage.xml
 *,cover
 *.log
 .git
+**/__pycache__
+**/*.pyc
+**/*.pyo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 sudo: required
 dist: trusty
+services:
+  - docker
 python:
   - "3.4"
 before_install:
@@ -17,4 +19,7 @@ install: "" # we don't want to use virtualenv (see below)
 # instead for both uncompiled and compiled modules.
 # The easiest way without hacking PYTHONPATH, PYTHONHOME is to use the system
 # python version by prepending it in the PATH.
-script: PATH="/usr/bin:$PATH" ./runtests pep8 small
+env:
+  - TESTFOLDER="pep8 small"
+  - TESTFOLDER="medium"
+script: PATH="/usr/bin:$PATH" ./runtests $TESTFOLDER

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,18 @@
 language: python
-sudo: required
-dist: trusty
-services:
-  - docker
 python:
   - "3.4"
+virtualenv:
+  system_site_packages: true
+
+dist: trusty
+sudo: required
+
+services:
+  - docker
+
 before_install:
-  - sudo add-apt-repository -y ppa:ubuntu-desktop/ubuntu-make
-  - sudo add-apt-repository -y ppa:ubuntu-desktop/ubuntu-make-builddeps
-  - sudo apt-get update
-# install binary deps
-  - sudo apt-get install -y $(tests/daily_runs/get_binary_depends ubuntu-make)
-# install tests requirements
-  - sudo tests/daily_runs/install_build_tests_depends
-install: "" # we don't want to use virtualenv (see below)
-# as we can't use a system virtualenv anymore in travis CI and that
-# python-gobject isn't installable in pypy, we have to use system libraries
-# instead for both uncompiled and compiled modules.
-# The easiest way without hacking PYTHONPATH, PYTHONHOME is to use the system
-# python version by prepending it in the PATH.
+  - sudo apt-get update -q
+  - sudo apt install -y gir1.2-gtk-3.0 python3-gi python3-gi-cairo
 env:
   - TESTFOLDER="pep8 small"
   - TESTFOLDER="medium"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,10 @@ sudo: required
 services:
   - docker
 
-before_install:
+install:
   - sudo apt-get update -q
-  - sudo apt install -y gir1.2-gtk-3.0 python3-gi python3-gi-cairo
+  - sudo apt install -y gir1.2-gtk-3.0 python3-gi python3-gi-cairo python3-apt
+  - pip install -r requirements.txt
 env:
   - TESTFOLDER="pep8 small"
   - TESTFOLDER="medium"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # runtime requirements
--e git://git.launchpad.net/python-apt@1.1.0_beta1#egg=apt
+#-e git://git.launchpad.net/python-apt@1.1.0_beta1#egg=apt
 argcomplete
 progressbar33
 pyyaml


### PR DESCRIPTION
Having the medium tests run frequently helps to avoid making a change and not checking the appropriate tests.
This PR introduces the docker image on travis ci, so we can run the medium tests as well as the small ones.
I'm using this to correct all standing issues in the testing interface, and checking if some frameworks have been needing support