### PR TITLE
Add env variables to android studio

### DIFF
--- a/umake/frameworks/android.py
+++ b/umake/frameworks/android.py
@@ -99,6 +99,8 @@ class AndroidStudio(umake.frameworks.baseinstaller.BaseInstaller):
 
     def post_install(self):
         """Create the Android Studio launcher"""
+        add_env_to_user(self.name, {"ANDROID_HOME": {"value": self.install_path, "keep": False},
+                                    "ANDROID_SDK": {"value": self.install_path, "keep": False}})
         create_launcher(self.desktop_filename, get_application_desktop_file(name=_("Android Studio"),
                         icon_path=os.path.join(self.install_path, "bin", "studio.png"),
                         try_exec=os.path.join(self.install_path, "bin", "studio.sh"),


### PR DESCRIPTION
This pr adds the env variables (ANDROID_HOME and ANDROID_SDK) to the android studio install.
This makes it so in a project the ide can find the emulator, gradle, ...