### PR TITLE
Edit snapcraft.yaml to fix coredump

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,14 +15,12 @@ confinement: classic
 
 apps:
   umake:
-    command: bin/umake-wrapper
+    command: bin/umake
 
 parts:
   umake:
     source: .
     plugin: python
-    organize:
-      lib/python3/dist-packages/umake: lib/python3.5/site-packages/umake
     build-packages:
       - gettext
       - python3
@@ -45,6 +43,9 @@ parts:
       - fakeroot
       - help2man
     stage-packages:
+      - gir1.2-gtk-3.0
+      - gir1.2-glib-2.0
+      - python3
       - python3-apt
       - python3-argcomplete
       - python3-bs4
@@ -54,20 +55,3 @@ parts:
       - python3-yaml
       - python3-requests
       - python3-xdg
-      - libstdc++6
-      - libc6
-      - libuuid1
-      - libreadline6
-      - libtinfo5
-      - libselinux1
-      - libpcre3
-      - libudev1
-      - zlib1g
-      - libbz2-1.0
-      - libgcc1
-      - liblzma5
-  umake-wrapper:
-    source: snap/
-    plugin: dump
-    organize:
-      umake-wrapper: bin/umake-wrapper


### PR DESCRIPTION
Fixes #500 #484 #480 
Now the snap runs fine on 18.04.
Not yet tested on the previous releases
With the latest change, removing the wrapper, it works on 16.04 and 17.10.