### PR TITLE
Supports autopkgtests now on artful+

### DIFF
--- a/debian/tests/custom
+++ b/debian/tests/custom
@@ -6,8 +6,8 @@ set -e
 # skip tests if not requested
 skip_if_no_in_list
 
-# require compiz to run as we might right large tests
-wait_for_compiz
+# require user session to run as we might have large tests
+wait_for_user_session
 
 run_tests $TESTS
 

--- a/debian/tests/large
+++ b/debian/tests/large
@@ -6,8 +6,8 @@ set -e
 # skip tests if not requested
 skip_if_no_in_list
 
-# require compiz to run
-wait_for_compiz
+# require user session to run
+wait_for_user_session
 
 run_tests large
 

--- a/debian/tests/setup-testbed
+++ b/debian/tests/setup-testbed
@@ -37,14 +37,11 @@ Section "Device"
 EndSection
 EOF
 
-# enable autologin to get unity started
-if [ ! -r /etc/lightdm/lightdm.conf.d/umaketests.conf ]; then
-    sudo -n mkdir -p /etc/lightdm/lightdm.conf.d
-    cat << EOF | sudo -n tee /etc/lightdm/lightdm.conf.d/umaketests.conf
-[SeatDefaults]
-autologin-user=ubuntu
+# enable autologin to get user session started
+cat << EOF | sudo -n tee -a /etc/gdm3/custom.conf
+AutomaticLoginEnable = true
+AutomaticLogin = ubuntu
 EOF
-fi
 
 # enable localhost ssh connection without pass
 ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa

--- a/debian/tests/utils
+++ b/debian/tests/utils
@@ -78,7 +78,7 @@ function run_tests {
 function wait_for_user_session {
     timeout=100
     # we want 2 gnome-sessions: one for gdm, one for the user session
-    while [ ! `pgrep -c gnome-session` -eq 2 ]; do
+    while [ ! `pgrep -c gnome-session` -gt 0 ]; do
         if [ $timeout -le 0 ]; then
             echo "gnome-session for users didn't start"
             echo "------------- journal: -------------"

--- a/debian/tests/utils
+++ b/debian/tests/utils
@@ -74,22 +74,21 @@ function run_tests {
     ssh -o StrictHostKeyChecking=no -t -t 127.0.0.1 "cd $PWD; DISPLAY=:0 dbus-launch ./runtests --publish --coverage $(add_runtests_opts) $@"
 }
 
-# wait for compiz to start, exit 1 after a timeout if not running.
-function wait_for_compiz {
+# wait for user session to start, exit 1 after a timeout if not running.
+function wait_for_user_session {
     timeout=100
-    while [ ! `pgrep -c compiz` -gt 0 ]; do
+    # we want 2 gnome-sessions: one for gdm, one for the user session
+    while [ ! `pgrep -c gnome-session` -eq 2 ]; do
         if [ $timeout -le 0 ]; then
-            echo "compiz didn't start"
-            echo "------------- /var/log/lightdm/x-0.log -------------"
-            sudo -n cat  /var/log/lightdm/x-0.log || true
-            echo "------------- /var/log/lightdm/.lightdm.log -------------"
-            sudo -n cat  /var/log/lightdm/lightdm.log || true
+            echo "gnome-session for users didn't start"
+            echo "------------- journal: -------------"
+            sudo -n journalctl -b || true
             echo "------------- ~/.xsession-errors -------------"
             cat  ~/.xsession-errors || true
             exit 1
         fi
         timeout=$((timeout - 5))
         sleep 5
-        echo "waiting for compiz to start... (${timeout}s left)"
+        echo "waiting for user session to start... (${timeout}s left)"
     done
 }


### PR DESCRIPTION
* swith from lightdm to gdm for loging manager autologin
* wait on 2 gnome-session process to run to start tests
* report correct log files