### PR TITLE
Add gnome launcher support

### DIFF
--- a/tests/small/test_tools.py
+++ b/tests/small/test_tools.py
@@ -478,6 +478,20 @@ class TestLauncherIcons(LoggedTestCase):
         self.assertEqual(open(get_launcher_path("foo.desktop")).read(), self.get_generic_desktop_content())
 
     @patch("umake.tools.Gio.Settings")
+    def test_can_install_gnome(self, SettingsMock):
+        """Install a basic launcher, default case in gnome"""
+        SettingsMock.list_schemas.return_value = ["foo", "bar", "org.gnome.shell", "baz"]
+        SettingsMock.return_value.get_strv.return_value = ["bar.desktop"]
+        create_launcher("foo.desktop", self.get_generic_desktop_content())
+
+        self.assertTrue(SettingsMock.list_schemas.called)
+        SettingsMock.return_value.get_strv.assert_called_with("favorite-apps")
+        SettingsMock.return_value.set_strv.assert_called_with("favorite-apps", ["bar.desktop", "foo.desktop"])
+
+        self.assertTrue(os.path.exists(get_launcher_path("foo.desktop")))
+        self.assertEqual(open(get_launcher_path("foo.desktop")).read(), self.get_generic_desktop_content())
+
+    @patch("umake.tools.Gio.Settings")
     def test_can_update_launcher(self, SettingsMock):
         """Update a launcher file"""
         SettingsMock.list_schemas.return_value = ["foo", "bar", "com.canonical.Unity.Launcher", "baz"]

--- a/umake/tools.py
+++ b/umake/tools.py
@@ -341,7 +341,7 @@ def create_launcher(desktop_filename, content):
             sleep(1.5)
             ##########
             gsettings.set_strv("favorites", launcher_list)
-    elif "org.gnome.shell" in Gio.Settings.list_schemas():
+    if "org.gnome.shell" in Gio.Settings.list_schemas():
         gsettings = Gio.Settings(schema_id="org.gnome.shell", path="/org/gnome/shell/")
         launcher_list = gsettings.get_strv("favorite-apps")
         if desktop_filename not in launcher_list:


### PR DESCRIPTION
This adds the installed frameworks to the gnome launcher (dock)
It's a clone of the unity version, with the necessary tweaks and a simple test.