### PR TITLE
Allow Eclipse 'medium' tests to run successfully

### DIFF
--- a/tests/medium/test_ide.py
+++ b/tests/medium/test_ide.py
@@ -68,7 +68,7 @@ class EclipseJEEIDEInContainer(ContainerTests, test_ide.EclipseJEEIDETests):
     TIMEOUT_STOP = 10
 
     def setUp(self):
-        self.hosts = {443: ["www.eclipse.org"]}
+        self.hosts = {443: ["www.eclipse.org"], 80: ["www.eclipse.org"]}
         # we reuse the android-studio repo
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'android')
         super().setUp()
@@ -87,7 +87,7 @@ class EclipsePHPIDEInContainer(ContainerTests, test_ide.EclipsePHPIDETests):
     TIMEOUT_STOP = 10
 
     def setUp(self):
-        self.hosts = {443: ["www.eclipse.org"]}
+        self.hosts = {443: ["www.eclipse.org"], 80: ["www.eclipse.org"]}
         # we reuse the android-studio repo
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'android')
         super().setUp()
@@ -106,7 +106,7 @@ class EclipseJSIDEInContainer(ContainerTests, test_ide.EclipseJSIDETests):
     TIMEOUT_STOP = 10
 
     def setUp(self):
-        self.hosts = {443: ["www.eclipse.org"]}
+        self.hosts = {443: ["www.eclipse.org"], 80: ["www.eclipse.org"]}
         # we reuse the android-studio repo
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'android')
         super().setUp()
@@ -125,7 +125,7 @@ class EclipseCPPIDEInContainer(ContainerTests, test_ide.EclipseCPPIDETests):
     TIMEOUT_STOP = 10
 
     def setUp(self):
-        self.hosts = {443: ["www.eclipse.org"]}
+        self.hosts = {443: ["www.eclipse.org"], 80: ["www.eclipse.org"]}
         # we reuse the android-studio repo
         self.apt_repo_override_path = os.path.join(self.APT_FAKE_REPO_PATH, 'android')
         super().setUp()

--- a/tests/tools/local_server.py
+++ b/tests/tools/local_server.py
@@ -200,6 +200,8 @@ class RequestHandler(SimpleHTTPRequestHandler):
         else:
             # keep special ?file= to redirect the query
             if '?file=' in self.path:
+                if '/downloads/sums.php?file=' in self.path:
+                    self.path += '.sha512'
                 self.path = self.path.split('?file=', 1)[1]
                 self.path = self.path.replace('&', '?', 1)  # Replace the first & with ? to make it valid.
             if RequestHandler.ftp_redir:

--- a/umake/frameworks/ide.py
+++ b/umake/frameworks/ide.py
@@ -64,6 +64,7 @@ class BaseEclipse(umake.frameworks.baseinstaller.BaseInstaller, metaclass=ABCMet
             kwargs["required_files_path"] = current_required_files_path
         download_page = 'https://www.eclipse.org/downloads/eclipse-packages/'
         kwargs["download_page"] = download_page
+        kwargs["checksum_type"] = ChecksumType.sha512
         super().__init__(*args, **kwargs)
         self.icon_url = os.path.join("https://www.eclipse.org/downloads/", "images", self.icon_filename)
         self.bits = '' if platform.machine() == 'i686' else 'x86_64'


### PR DESCRIPTION
I ran the following command:
`./runtests tests/medium/test_ide.py:EclipseJavaIDEInContainer tests/medium/test_ide.py:EclipseJEEIDEInContainer tests/medium/test_ide.py:EclipsePHPIDEInContainer tests/medium/test_ide.py:EclipseJSIDEInContainer tests/medium/test_ide.py:EclipseCPPIDEInContainer &> medium.log`

and go the following output:
```
[nose.plugins.manager] DEBUG: DefaultPluginManager load plugin nose_json = nose_json.plugin:JsonReportPlugin
[nose.plugins.manager] DEBUG: DefaultPluginManager load plugin cov = nose_cov:Cov
[nose_cov] DEBUG: nose-cov options
[nose_cov] DEBUG: nose-cov configure
.......
----------------------------------------------------------------------
Ran 7 tests in 164.090s

OK
```