### PR TITLE
update godot logo URL

### DIFF
--- a/umake/frameworks/games.py
+++ b/umake/frameworks/games.py
@@ -182,7 +182,7 @@ class Godot(umake.frameworks.baseinstaller.BaseInstaller):
                          desktop_filename="godot.desktop",
                          required_files_path=['godot'],
                          **kwargs)
-        self.icon_url = "https://godotengine.org/themes/godotengine/assets/download/godot_logo.svg"
+        self.icon_url = "https://godotengine.org/assets/press/icon_color.svg"
         self.icon_filename = "Godot.svg"
 
     arch_trans = {


### PR DESCRIPTION
I am seeing some errors while trying to install godot through ubuntu-make saying the logo URL does not exist, so I am submitting this PR. Not sure if this is going to completely fix the problem though. Do let me know if there are other things I need to include as part of the PR.