### PR TITLE
remove obsolete requirement for vscode

### DIFF
--- a/umake/frameworks/ide.py
+++ b/umake/frameworks/ide.py
@@ -512,7 +512,7 @@ class VisualStudioCode(umake.frameworks.baseinstaller.BaseInstaller):
                          desktop_filename="visual-studio-code.desktop",
                          required_files_path=["bin/code"],
                          dir_to_decompress_in_tarball="VSCode-linux-*",
-                         packages_requirements=["libgtk2.0-0", "libgconf-2-4"],
+                         packages_requirements=["libgtk2.0-0"],
                          **kwargs)
 
     def parse_license(self, line, license_txt, in_license):


### PR DESCRIPTION
I just updated to Ubuntu 24.04, and tested that latest version of vscode does not require libgconf-2-4 anymore, please let me know if are other things to fix