### PR TITLE
Adapt to the changes in godot download page

### DIFF
--- a/umake/frameworks/games.py
+++ b/umake/frameworks/games.py
@@ -196,7 +196,7 @@ class Godot(umake.frameworks.baseinstaller.BaseInstaller):
                          desktop_filename="godot.desktop",
                          required_files_path=['godot'],
                          **kwargs)
-        self.icon_url = "https://godotengine.org/assets/press/icon_color.png"
+        self.icon_url = "https://godotengine.org/assets/press/icon_color.svg"
         self.icon_filename = "Godot.svg"
 
     arch_trans = {

--- a/umake/frameworks/games.py
+++ b/umake/frameworks/games.py
@@ -21,6 +21,7 @@
 """Game IDEs module"""
 
 from contextlib import suppress
+from html.parser import HTMLParser
 from gettext import gettext as _
 import logging
 import os
@@ -194,7 +195,7 @@ class Godot(umake.frameworks.baseinstaller.BaseInstaller):
         url = None
         if '{}.zip'.format(self.arch_trans[get_current_arch()]) in line:
             in_download = True
-            p = re.search(r'(.*\.zip)', line)
+            p = re.search(r'.*href=(.*\.zip)', line)
             with suppress(AttributeError):
                 url = p.group(1)
                 bin = re.search(r'(Godot.*)\.zip', url)

--- a/umake/frameworks/games.py
+++ b/umake/frameworks/games.py
@@ -194,7 +194,7 @@ class Godot(umake.frameworks.baseinstaller.BaseInstaller):
         url = None
         if '{}.zip'.format(self.arch_trans[get_current_arch()]) in line:
             in_download = True
-            p = re.search(r'.*href=(.*\.zip)', line)
+            p = re.search(r'.*href=\"?([^\s]+\.zip)', line)
             with suppress(AttributeError):
                 url = p.group(1)
                 bin = re.search(r'(Godot.*)\.zip', url)

--- a/umake/frameworks/games.py
+++ b/umake/frameworks/games.py
@@ -21,7 +21,6 @@
 """Game IDEs module"""
 
 from contextlib import suppress
-from html.parser import HTMLParser
 from gettext import gettext as _
 import logging
 import os

--- a/umake/frameworks/games.py
+++ b/umake/frameworks/games.py
@@ -182,7 +182,7 @@ class Godot(umake.frameworks.baseinstaller.BaseInstaller):
                          desktop_filename="godot.desktop",
                          required_files_path=['godot'],
                          **kwargs)
-        self.icon_url = "https://godotengine.org/themes/godotengine/assets/download/godot_logo.svg"
+        self.icon_url = "https://godotengine.org/assets/press/icon_color.png"
         self.icon_filename = "Godot.svg"
 
     arch_trans = {

--- a/umake/frameworks/games.py
+++ b/umake/frameworks/games.py
@@ -208,7 +208,7 @@ class Godot(umake.frameworks.baseinstaller.BaseInstaller):
         url = None
         if '{}.zip'.format(self.arch_trans[get_current_arch()]) in line:
             in_download = True
-            p = re.search(r'.*href=\"?([^\s]+\.zip)', line)
+            p = re.search(r'href=\"?([^\s]+\.zip)', line)
             with suppress(AttributeError):
                 url = p.group(1)
                 bin = re.search(r'(Godot.*)\.zip', url)


### PR DESCRIPTION
This is a minor patch to fix godot installation with umake. Long term fix would be introducing a proper html parser but for now this fix will do.